### PR TITLE
feat: add terraform for OCI deployment

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -2,9 +2,6 @@ name: Build and Push Images
 
 on:
   pull_request:
-    branches:
-      - main
-      - beta
     paths:
       - 'formulatel/**'
       - 'migrations/**'
@@ -38,6 +35,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -57,6 +57,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=sha,enable=true
+            type=semver,pattern={{version}}
 
       - name: Build and push persist image
         uses: docker/build-push-action@v5
@@ -64,6 +65,7 @@ jobs:
           context: ${{ matrix.build_context }}
           file: ${{ matrix.dockerfile }}
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'formulatel/**'
       - 'migrations/**'
+      - '.github/workflows/**'
   push:
     branches:
       - main

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ captured_packets/
 .claude/*
 # maybe I should include the memory files as well, not sure
 !.claude/agents/
+.terraform/
 out/
 formulatel/cmd/decode/
 *.out
 coverage.*
+sandbox.tfvars

--- a/formulatel/persist.Dockerfile
+++ b/formulatel/persist.Dockerfile
@@ -1,4 +1,4 @@
-FROM FROM --platform=$BUILDPLATFORM golang:1.26.4 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.4 AS build
 
 WORKDIR /src
 

--- a/formulatel/persist.Dockerfile
+++ b/formulatel/persist.Dockerfile
@@ -1,14 +1,19 @@
-# TODO: use latest major version?
-FROM golang:1.25.1 AS build
+FROM FROM --platform=$BUILDPLATFORM golang:1.26.4 AS build
 
 WORKDIR /src
 
 COPY . .
 
+ARG TARGETOS
+ARG TARGETARCH
+
+# this was for OBI; I never got OBI working properly, so I don't know if these were ever needed.
+# they were an AI suggestion, the root cause for which I did not grok
 # -gcflags="all=-N -l" -ldflags="-extldflags=-static" # add these build flags to `go build` to produce an
 # unoptimized binary without inlining or ELF optimization.
-RUN mkdir out && CGO_ENABLED=0 GOOS=linux go build -o ./out/persist ./cmd/persist
+RUN mkdir out && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o ./out/persist ./cmd/persist
 
+# the `debug` tag provides an image with a shell for us to exec into when the container is running
 FROM gcr.io/distroless/static-debian13:debug
 
 COPY --from=build /src/out/persist /

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/oracle/oci" {
+  version     = "8.20.0"
+  constraints = "8.20.0"
+  hashes = [
+    "h1:kHXI4Yo+cVUI7anLBroJK0CZYxQfAEIYohNFpi6KbDc=",
+    "zh:01b943c412c97f257d2602d3fafcdd70ca06e61da5b57e5a49b049a54752905d",
+    "zh:0b574610e661ac6fe1521a68b1beb461b67cedcc10211b1a4034ca61bc8d1f07",
+    "zh:0c6fc339c16fad60fe3f7e2bfdf8d4e8ae4b553280f7844de06231ae7ec2af62",
+    "zh:0deb97d3a1a573b53308d247585ec55b87e6ca98c21aad4601add05be278ecf7",
+    "zh:133d9536aca4790ef409de49977f9500971ad04efdfde4bb7794aba739cf2342",
+    "zh:1403c609bb39a902c221c807b3b87f12ec67c172ec20540e8b1a3e639ef1786a",
+    "zh:529930f777b0de811c5e765c2fea032313b8187ddc861af2ee51e6c57ad64aa1",
+    "zh:5d137170ab6d273982438045f12e174cb3d8cc42381132ee62b10455e0ac5da4",
+    "zh:9830d08e9b142d83f336167d6be82c7615c14b00b97dd08e598f29367574d612",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c03479c9ba577c14df11c7a25e2391658e09601d2df9f00037689df4eb3acbaf",
+    "zh:d73d4e34ac6f984b4b82e953fa7190ae5e1806256878d0fbb22276bf21d69f4b",
+    "zh:dad9da3c253c9121e735d8eeee90e609aa440eb9a01e15fc3d6726d4d010300c",
+    "zh:e8f24c40631ce46799435466bbb9cfce14d888be9c209d87bfb8f17231002c81",
+    "zh:f032a6758fdefee32596d7a26b58dc44fc63dcc46f2fceec0d167a9cbf6150cd",
+  ]
+}

--- a/terraform/k8s_server.tf
+++ b/terraform/k8s_server.tf
@@ -1,0 +1,102 @@
+# Create the Virtual Cloud Network (VCN)
+resource "oci_core_vcn" "formulatel_vcn" {
+  cidr_block     = "10.0.0.0/16"
+  compartment_id = var.compartment_ocid
+  display_name   = "formulatel-network"
+}
+
+# Internet Gateway to allow public traffic in
+resource "oci_core_internet_gateway" "ig" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.formulatel_vcn.id
+  display_name   = "internet-gateway"
+}
+
+# Route Table to route internet traffic
+resource "oci_core_route_table" "rt" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.formulatel_vcn.id
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_internet_gateway.ig.id
+  }
+}
+
+# Public Subnet
+resource "oci_core_subnet" "public_subnet" {
+  compartment_id    = var.compartment_ocid
+  cidr_block        = "10.0.1.0/24"
+  vcn_id            = oci_core_vcn.formulatel_vcn.id
+  route_table_id    = oci_core_route_table.rt.id
+  display_name      = "public-subnet"
+}
+
+# Network Security Group
+resource "oci_core_network_security_group" "vm_nsg" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.formulatel_vcn.id
+  display_name   = "formulatel-security-group"
+}
+
+# Restrict SSH (22) to a specific IP address
+resource "oci_core_network_security_group_security_rule" "ssh_rule" {
+  network_security_group_id = oci_core_network_security_group.vm_nsg.id
+  direction                 = "INGRESS"
+  protocol                  = "6" # TCP
+  source                    = "${var.home_ip}/32"
+  source_type               = "CIDR_BLOCK"
+  tcp_options {
+    destination_port_range {
+      min = 22
+      max = 22
+    }
+  }
+}
+
+# Rule: Open MQTT (1883) to the world so your gaming PC can stream data
+resource "oci_core_network_security_group_security_rule" "mqtt_rule" {
+  network_security_group_id = oci_core_network_security_group.vm_nsg.id
+  direction                 = "INGRESS"
+  protocol                  = "6"
+  source                    = "0.0.0.0/0"
+  source_type               = "CIDR_BLOCK"
+  tcp_options {
+    destination_port_range {
+      min = 1883
+      max = 1883
+    }
+  }
+}
+
+# Always-Free Ampere Compute Instance - this is where our k8s and postgres install will live
+resource "oci_core_instance" "single_node_k8s" {
+  availability_domain = var.availability_domain
+  compartment_id      = var.compartment_ocid
+  shape               = "VM.Standard.A1.Flex" # The Always Free ARM Shape
+
+  # the free tier allows us enough CPU and memory credits to run 2 OCPUs and 12GB of memory 24/7.
+  # hopefully this is sufficient to run postgres+timescaleDB along with a slim kubernetes distribution
+  # on Ubuntu
+  shape_config {
+    ocpus         = 2  # Split the free tier allocation safely
+    memory_in_gbs = 12
+  }
+
+  create_vnic_details {
+    subnet_id        = oci_core_subnet.public_subnet.id
+    nsg_ids          = [oci_core_network_security_group.vm_nsg.id]
+    assign_public_ip = true
+  }
+
+  source_details {
+    source_type = "image"
+    source_id   = var.ubuntu_arm_image_ocid
+  }
+
+  # TODO: add user data setup script: open iptables, install postgres, install k3s
+  metadata = {
+    ssh_authorized_keys = file("~/.ssh/id_rsa.pub")
+    # user_data           = base64encode(file("${path.module}/bootstrap.sh"))
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "8.20.0"
+    }
+  }
+}
+
+provider "oci" {}

--- a/terraform/terraform.tfstate
+++ b/terraform/terraform.tfstate
@@ -1,0 +1,303 @@
+{
+  "version": 4,
+  "terraform_version": "1.15.7",
+  "serial": 9,
+  "lineage": "60f31ba0-c03a-4721-bfa3-966d7add6e3e",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "oci_core_internet_gateway",
+      "name": "ig",
+      "provider": "provider[\"registry.terraform.io/oracle/oci\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "compartment_id": "ocid1.tenancy.oc1..aaaaaaaa37amnhgpmjpo3lkugmmbqrb3ojxtwb7hxqdfahkmwarrvw3mhgka",
+            "defined_tags": {
+              "Oracle-Tags.CreatedBy": "default/isnor.james@gmail.com",
+              "Oracle-Tags.CreatedOn": "2026-06-26T17:27:30.249Z"
+            },
+            "display_name": "internet-gateway",
+            "enabled": true,
+            "freeform_tags": {},
+            "id": "ocid1.internetgateway.oc1.ca-montreal-1.aaaaaaaahd4aep2k7vosyggn6z2wyv65ptz6ianjwwyvjzg7fjfubozamw6a",
+            "route_table_id": null,
+            "state": "AVAILABLE",
+            "time_created": "2026-06-26 17:27:30.293 +0000 UTC",
+            "timeouts": null,
+            "vcn_id": "ocid1.vcn.oc1.ca-montreal-1.amaaaaaa2n77griaolerp3fatdyhv7xgb6bzvxr7ixgcihgujjler4n4uuoq"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "oci_core_vcn.formulatel_vcn"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "oci_core_network_security_group",
+      "name": "vm_nsg",
+      "provider": "provider[\"registry.terraform.io/oracle/oci\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "compartment_id": "ocid1.tenancy.oc1..aaaaaaaa37amnhgpmjpo3lkugmmbqrb3ojxtwb7hxqdfahkmwarrvw3mhgka",
+            "defined_tags": {
+              "Oracle-Tags.CreatedBy": "default/isnor.james@gmail.com",
+              "Oracle-Tags.CreatedOn": "2026-06-26T17:27:30.065Z"
+            },
+            "display_name": "formulatel-security-group",
+            "freeform_tags": {},
+            "id": "ocid1.networksecuritygroup.oc1.ca-montreal-1.aaaaaaaaobzamx6biafn6cl6dj6v46ee7bqsmswfxjb455wni4l57gymrlna",
+            "state": "AVAILABLE",
+            "time_created": "2026-06-26 17:27:30.153 +0000 UTC",
+            "timeouts": null,
+            "vcn_id": "ocid1.vcn.oc1.ca-montreal-1.amaaaaaa2n77griaolerp3fatdyhv7xgb6bzvxr7ixgcihgujjler4n4uuoq"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "oci_core_vcn.formulatel_vcn"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "oci_core_network_security_group_security_rule",
+      "name": "mqtt_rule",
+      "provider": "provider[\"registry.terraform.io/oracle/oci\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "description": null,
+            "destination": null,
+            "destination_type": "",
+            "direction": "INGRESS",
+            "icmp_options": [],
+            "id": "759880",
+            "is_valid": true,
+            "network_security_group_id": "ocid1.networksecuritygroup.oc1.ca-montreal-1.aaaaaaaaobzamx6biafn6cl6dj6v46ee7bqsmswfxjb455wni4l57gymrlna",
+            "protocol": "6",
+            "source": "0.0.0.0/0",
+            "source_type": "CIDR_BLOCK",
+            "stateless": false,
+            "tcp_options": [
+              {
+                "destination_port_range": [
+                  {
+                    "max": 1883,
+                    "min": 1883
+                  }
+                ],
+                "source_port_range": []
+              }
+            ],
+            "time_created": "2026-06-26 17:27:30.653 +0000 UTC",
+            "timeouts": null,
+            "udp_options": []
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "oci_core_network_security_group.vm_nsg",
+            "oci_core_vcn.formulatel_vcn"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "oci_core_network_security_group_security_rule",
+      "name": "ssh_rule",
+      "provider": "provider[\"registry.terraform.io/oracle/oci\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "description": null,
+            "destination": null,
+            "destination_type": "",
+            "direction": "INGRESS",
+            "icmp_options": [],
+            "id": "39B706",
+            "is_valid": true,
+            "network_security_group_id": "ocid1.networksecuritygroup.oc1.ca-montreal-1.aaaaaaaaobzamx6biafn6cl6dj6v46ee7bqsmswfxjb455wni4l57gymrlna",
+            "protocol": "6",
+            "source": "142.67.240.101/32",
+            "source_type": "CIDR_BLOCK",
+            "stateless": false,
+            "tcp_options": [
+              {
+                "destination_port_range": [
+                  {
+                    "max": 22,
+                    "min": 22
+                  }
+                ],
+                "source_port_range": []
+              }
+            ],
+            "time_created": "2026-06-26 17:27:30.48 +0000 UTC",
+            "timeouts": null,
+            "udp_options": []
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "oci_core_network_security_group.vm_nsg",
+            "oci_core_vcn.formulatel_vcn"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "oci_core_route_table",
+      "name": "rt",
+      "provider": "provider[\"registry.terraform.io/oracle/oci\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "compartment_id": "ocid1.tenancy.oc1..aaaaaaaa37amnhgpmjpo3lkugmmbqrb3ojxtwb7hxqdfahkmwarrvw3mhgka",
+            "defined_tags": {
+              "Oracle-Tags.CreatedBy": "default/isnor.james@gmail.com",
+              "Oracle-Tags.CreatedOn": "2026-06-26T17:27:30.709Z"
+            },
+            "display_name": "routetable20260626172730",
+            "freeform_tags": {},
+            "id": "ocid1.routetable.oc1.ca-montreal-1.aaaaaaaadsyd4jvjzn5shrkircozrnpi4we6pcuwjjrzbq7vwfvzkaozuewa",
+            "route_rules": [
+              {
+                "cidr_block": "",
+                "description": "",
+                "destination": "0.0.0.0/0",
+                "destination_type": "CIDR_BLOCK",
+                "network_entity_id": "ocid1.internetgateway.oc1.ca-montreal-1.aaaaaaaahd4aep2k7vosyggn6z2wyv65ptz6ianjwwyvjzg7fjfubozamw6a",
+                "route_type": "STATIC"
+              }
+            ],
+            "state": "AVAILABLE",
+            "time_created": "2026-06-26 17:27:30.725 +0000 UTC",
+            "timeouts": null,
+            "vcn_id": "ocid1.vcn.oc1.ca-montreal-1.amaaaaaa2n77griaolerp3fatdyhv7xgb6bzvxr7ixgcihgujjler4n4uuoq"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "oci_core_internet_gateway.ig",
+            "oci_core_vcn.formulatel_vcn"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "oci_core_subnet",
+      "name": "public_subnet",
+      "provider": "provider[\"registry.terraform.io/oracle/oci\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "availability_domain": null,
+            "cidr_block": "10.0.1.0/24",
+            "compartment_id": "ocid1.tenancy.oc1..aaaaaaaa37amnhgpmjpo3lkugmmbqrb3ojxtwb7hxqdfahkmwarrvw3mhgka",
+            "defined_tags": {
+              "Oracle-Tags.CreatedBy": "default/isnor.james@gmail.com",
+              "Oracle-Tags.CreatedOn": "2026-06-26T17:27:31.033Z"
+            },
+            "dhcp_options_id": "ocid1.dhcpoptions.oc1.ca-montreal-1.aaaaaaaamhqnm4p542iro6anfk3f5adoyji7n6xny53b7b76lbrb7sbvtkeq",
+            "display_name": "public-subnet",
+            "dns_label": null,
+            "freeform_tags": {},
+            "id": "ocid1.subnet.oc1.ca-montreal-1.aaaaaaaavwyoj7lxms6vc2t222hd7oqqftzqj4gtfdxuolfaz5nsnlaqqgja",
+            "ipv4cidr_blocks": [
+              "10.0.1.0/24"
+            ],
+            "ipv6cidr_block": null,
+            "ipv6cidr_blocks": [],
+            "ipv6virtual_router_ip": null,
+            "prohibit_internet_ingress": false,
+            "prohibit_public_ip_on_vnic": false,
+            "route_table_id": "ocid1.routetable.oc1.ca-montreal-1.aaaaaaaadsyd4jvjzn5shrkircozrnpi4we6pcuwjjrzbq7vwfvzkaozuewa",
+            "security_list_ids": [
+              "ocid1.securitylist.oc1.ca-montreal-1.aaaaaaaakfxqv5hzmk6rhk7ux3e23ykopxydfy3kvbyukxpnquuc343e7mqa"
+            ],
+            "state": "AVAILABLE",
+            "subnet_domain_name": null,
+            "time_created": "2026-06-26 17:27:31.08 +0000 UTC",
+            "timeouts": null,
+            "vcn_id": "ocid1.vcn.oc1.ca-montreal-1.amaaaaaa2n77griaolerp3fatdyhv7xgb6bzvxr7ixgcihgujjler4n4uuoq",
+            "virtual_router_ip": "10.0.1.1",
+            "virtual_router_mac": "00:00:17:BE:EB:08"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "oci_core_internet_gateway.ig",
+            "oci_core_route_table.rt",
+            "oci_core_vcn.formulatel_vcn"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "oci_core_vcn",
+      "name": "formulatel_vcn",
+      "provider": "provider[\"registry.terraform.io/oracle/oci\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "byoipv6cidr_blocks": [],
+            "byoipv6cidr_details": [],
+            "cidr_block": "10.0.0.0/16",
+            "cidr_blocks": [
+              "10.0.0.0/16"
+            ],
+            "compartment_id": "ocid1.tenancy.oc1..aaaaaaaa37amnhgpmjpo3lkugmmbqrb3ojxtwb7hxqdfahkmwarrvw3mhgka",
+            "default_dhcp_options_id": "ocid1.dhcpoptions.oc1.ca-montreal-1.aaaaaaaamhqnm4p542iro6anfk3f5adoyji7n6xny53b7b76lbrb7sbvtkeq",
+            "default_route_table_id": "ocid1.routetable.oc1.ca-montreal-1.aaaaaaaaimon7ycinruvgoin5k242gquzc2yktqvyc7gf3soqu74trh2kb6q",
+            "default_security_list_id": "ocid1.securitylist.oc1.ca-montreal-1.aaaaaaaakfxqv5hzmk6rhk7ux3e23ykopxydfy3kvbyukxpnquuc343e7mqa",
+            "defined_tags": {
+              "Oracle-Tags.CreatedBy": "default/isnor.james@gmail.com",
+              "Oracle-Tags.CreatedOn": "2026-06-26T17:27:29.475Z"
+            },
+            "display_name": "formulatel-network",
+            "dns_label": null,
+            "freeform_tags": {},
+            "id": "ocid1.vcn.oc1.ca-montreal-1.amaaaaaa2n77griaolerp3fatdyhv7xgb6bzvxr7ixgcihgujjler4n4uuoq",
+            "ipv6cidr_blocks": [],
+            "ipv6private_cidr_blocks": [],
+            "is_ipv6enabled": false,
+            "is_oracle_gua_allocation_enabled": null,
+            "security_attributes": {},
+            "state": "AVAILABLE",
+            "time_created": "2026-06-26 17:27:29.553 +0000 UTC",
+            "timeouts": null,
+            "vcn_domain_name": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19"
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -1,0 +1,17 @@
+variable "compartment_ocid" {
+  type = string
+  description = "ID of the compartment to deploy these resources in"
+}
+
+variable "availability_domain" {
+  type = string
+}
+
+variable "home_ip" {
+  type = string
+  description = "an IPv4 address to allow SSH traffic from"
+}
+
+variable "ubuntu_arm_image_ocid" {
+  type = string
+}

--- a/terraform/vars/.gitkeep
+++ b/terraform/vars/.gitkeep
@@ -1,0 +1,3 @@
+# deploy to your own tenancy
+
+Use this folder to define the `tfvars` for your environment, or possibly think of a better way to store the secrets we don't want to commit


### PR DESCRIPTION
This is pretty neat: turns out Oracle's cloud has a very generous free tier for ARM64 CPUs, enough to run 4 vCPUs and 24GB of memory with 200GB of block storage. This should be plenty to demo `formulatel` as a service, even if it only supports a few concurrent users.

This PR adds a build for ARM64 images and the terraform that I've deployed so far for our single-node k8s/postgres instance. The plan right now is to install [postgres+timescaledb](https://www.tigerdata.com/docs/get-started/choose-your-path/install-timescaledb#tab=ubuntu) and [k3s](https://github.com/k3s-io/k3s/) on the same machine and use `kubectl` from my workstation to install the rest of `formulatel`.

If that actually works, maybe we'll look at splitting into two instances. 