### PR TITLE
feat: add terraform for OCI

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -2,12 +2,10 @@ name: Build and Push Images
 
 on:
   pull_request:
-    branches:
-      - main
-      - beta
     paths:
       - 'formulatel/**'
       - 'migrations/**'
+      - '.github/workflows/**'
   push:
     branches:
       - main
@@ -38,6 +36,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -57,6 +58,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=sha,enable=true
+            type=semver,pattern={{version}}
 
       - name: Build and push persist image
         uses: docker/build-push-action@v5
@@ -64,6 +66,7 @@ jobs:
           context: ${{ matrix.build_context }}
           file: ${{ matrix.dockerfile }}
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,11 @@ captured_packets/
 .claude/*
 # maybe I should include the memory files as well, not sure
 !.claude/agents/
+.terraform/
+*.tfstate*
+*.tfvars
 out/
 formulatel/cmd/decode/
 *.out
 coverage.*
+sandbox.tfvars

--- a/formulatel/persist.Dockerfile
+++ b/formulatel/persist.Dockerfile
@@ -1,14 +1,19 @@
-# TODO: use latest major version?
-FROM golang:1.25.1 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.4 AS build
 
 WORKDIR /src
 
 COPY . .
 
+ARG TARGETOS
+ARG TARGETARCH
+
+# this was for OBI; I never got OBI working properly, so I don't know if these were ever needed.
+# they were an AI suggestion, the root cause for which I did not grok
 # -gcflags="all=-N -l" -ldflags="-extldflags=-static" # add these build flags to `go build` to produce an
 # unoptimized binary without inlining or ELF optimization.
-RUN mkdir out && CGO_ENABLED=0 GOOS=linux go build -o ./out/persist ./cmd/persist
+RUN mkdir out && CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o ./out/persist ./cmd/persist
 
+# the `debug` tag provides an image with a shell for us to exec into when the container is running
 FROM gcr.io/distroless/static-debian13:debug
 
 COPY --from=build /src/out/persist /

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/oracle/oci" {
+  version     = "8.20.0"
+  constraints = "8.20.0"
+  hashes = [
+    "h1:kHXI4Yo+cVUI7anLBroJK0CZYxQfAEIYohNFpi6KbDc=",
+    "zh:01b943c412c97f257d2602d3fafcdd70ca06e61da5b57e5a49b049a54752905d",
+    "zh:0b574610e661ac6fe1521a68b1beb461b67cedcc10211b1a4034ca61bc8d1f07",
+    "zh:0c6fc339c16fad60fe3f7e2bfdf8d4e8ae4b553280f7844de06231ae7ec2af62",
+    "zh:0deb97d3a1a573b53308d247585ec55b87e6ca98c21aad4601add05be278ecf7",
+    "zh:133d9536aca4790ef409de49977f9500971ad04efdfde4bb7794aba739cf2342",
+    "zh:1403c609bb39a902c221c807b3b87f12ec67c172ec20540e8b1a3e639ef1786a",
+    "zh:529930f777b0de811c5e765c2fea032313b8187ddc861af2ee51e6c57ad64aa1",
+    "zh:5d137170ab6d273982438045f12e174cb3d8cc42381132ee62b10455e0ac5da4",
+    "zh:9830d08e9b142d83f336167d6be82c7615c14b00b97dd08e598f29367574d612",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c03479c9ba577c14df11c7a25e2391658e09601d2df9f00037689df4eb3acbaf",
+    "zh:d73d4e34ac6f984b4b82e953fa7190ae5e1806256878d0fbb22276bf21d69f4b",
+    "zh:dad9da3c253c9121e735d8eeee90e609aa440eb9a01e15fc3d6726d4d010300c",
+    "zh:e8f24c40631ce46799435466bbb9cfce14d888be9c209d87bfb8f17231002c81",
+    "zh:f032a6758fdefee32596d7a26b58dc44fc63dcc46f2fceec0d167a9cbf6150cd",
+  ]
+}

--- a/terraform/k8s_server.tf
+++ b/terraform/k8s_server.tf
@@ -39,6 +39,8 @@ resource "oci_core_network_security_group" "vm_nsg" {
   display_name   = "formulatel-security-group"
 }
 
+# TODO: remove the ssh and k8s rule, use tailscale instead
+
 # Restrict SSH (22) to a specific IP address
 resource "oci_core_network_security_group_security_rule" "ssh_rule" {
   network_security_group_id = oci_core_network_security_group.vm_nsg.id
@@ -54,7 +56,23 @@ resource "oci_core_network_security_group_security_rule" "ssh_rule" {
   }
 }
 
-# Rule: Open MQTT (1883) to the world so your gaming PC can stream data
+# Restrict kube-server (6443) to specific IP address
+resource "oci_core_network_security_group_security_rule" "k8s_rule" {
+  network_security_group_id = oci_core_network_security_group.vm_nsg.id
+  direction                 = "INGRESS"
+  protocol                  = "6" # TCP
+  source                    = "${var.home_ip}/32"
+  source_type               = "CIDR_BLOCK"
+  tcp_options {
+    destination_port_range {
+      min = 6443
+      max = 6443
+    }
+  }
+}
+
+# Open MQTT (1883) to the world
+# TODO: restrict this to some list of NA CIDR blocks instead of the entire world.
 resource "oci_core_network_security_group_security_rule" "mqtt_rule" {
   network_security_group_id = oci_core_network_security_group.vm_nsg.id
   direction                 = "INGRESS"
@@ -75,12 +93,12 @@ resource "oci_core_instance" "single_node_k8s" {
   compartment_id      = var.compartment_ocid
   shape               = "VM.Standard.A1.Flex" # The Always Free ARM Shape
 
-  # the free tier allows us enough CPU and memory credits to run 2 OCPUs and 12GB of memory 24/7.
+  # the free tier allows us enough CPU and memory credits to run 4 OCPUs and 24GB of memory 24/7.
   # hopefully this is sufficient to run postgres+timescaleDB along with a slim kubernetes distribution
   # on Ubuntu
   shape_config {
-    ocpus         = 2  # Split the free tier allocation safely
-    memory_in_gbs = 12
+    ocpus         = 4
+    memory_in_gbs = 24
   }
 
   create_vnic_details {
@@ -94,9 +112,8 @@ resource "oci_core_instance" "single_node_k8s" {
     source_id   = var.ubuntu_arm_image_ocid
   }
 
-  # TODO: add user data setup script: open iptables, install postgres, install k3s
   metadata = {
     ssh_authorized_keys = file("~/.ssh/id_rsa.pub")
-    # user_data           = base64encode(file("${path.module}/bootstrap.sh"))
+    user_data           = base64encode(file("${path.module}/setup-server.sh"))
   }
 }

--- a/terraform/k8s_server.tf
+++ b/terraform/k8s_server.tf
@@ -1,0 +1,102 @@
+# Create the Virtual Cloud Network (VCN)
+resource "oci_core_vcn" "formulatel_vcn" {
+  cidr_block     = "10.0.0.0/16"
+  compartment_id = var.compartment_ocid
+  display_name   = "formulatel-network"
+}
+
+# Internet Gateway to allow public traffic in
+resource "oci_core_internet_gateway" "ig" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.formulatel_vcn.id
+  display_name   = "internet-gateway"
+}
+
+# Route Table to route internet traffic
+resource "oci_core_route_table" "rt" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.formulatel_vcn.id
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_internet_gateway.ig.id
+  }
+}
+
+# Public Subnet
+resource "oci_core_subnet" "public_subnet" {
+  compartment_id    = var.compartment_ocid
+  cidr_block        = "10.0.1.0/24"
+  vcn_id            = oci_core_vcn.formulatel_vcn.id
+  route_table_id    = oci_core_route_table.rt.id
+  display_name      = "public-subnet"
+}
+
+# Network Security Group
+resource "oci_core_network_security_group" "vm_nsg" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_vcn.formulatel_vcn.id
+  display_name   = "formulatel-security-group"
+}
+
+# Restrict SSH (22) to a specific IP address
+resource "oci_core_network_security_group_security_rule" "ssh_rule" {
+  network_security_group_id = oci_core_network_security_group.vm_nsg.id
+  direction                 = "INGRESS"
+  protocol                  = "6" # TCP
+  source                    = "${var.home_ip}/32"
+  source_type               = "CIDR_BLOCK"
+  tcp_options {
+    destination_port_range {
+      min = 22
+      max = 22
+    }
+  }
+}
+
+# Rule: Open MQTT (1883) to the world so your gaming PC can stream data
+resource "oci_core_network_security_group_security_rule" "mqtt_rule" {
+  network_security_group_id = oci_core_network_security_group.vm_nsg.id
+  direction                 = "INGRESS"
+  protocol                  = "6"
+  source                    = "0.0.0.0/0"
+  source_type               = "CIDR_BLOCK"
+  tcp_options {
+    destination_port_range {
+      min = 1883
+      max = 1883
+    }
+  }
+}
+
+# Always-Free Ampere Compute Instance - this is where our k8s and postgres install will live
+resource "oci_core_instance" "single_node_k8s" {
+  availability_domain = var.availability_domain
+  compartment_id      = var.compartment_ocid
+  shape               = "VM.Standard.A1.Flex" # The Always Free ARM Shape
+
+  # the free tier allows us enough CPU and memory credits to run 2 OCPUs and 12GB of memory 24/7.
+  # hopefully this is sufficient to run postgres+timescaleDB along with a slim kubernetes distribution
+  # on Ubuntu
+  shape_config {
+    ocpus         = 2  # Split the free tier allocation safely
+    memory_in_gbs = 12
+  }
+
+  create_vnic_details {
+    subnet_id        = oci_core_subnet.public_subnet.id
+    nsg_ids          = [oci_core_network_security_group.vm_nsg.id]
+    assign_public_ip = true
+  }
+
+  source_details {
+    source_type = "image"
+    source_id   = var.ubuntu_arm_image_ocid
+  }
+
+  # TODO: add user data setup script: open iptables, install postgres, install k3s
+  metadata = {
+    ssh_authorized_keys = file("~/.ssh/id_rsa.pub")
+    # user_data           = base64encode(file("${path.module}/bootstrap.sh"))
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = "8.20.0"
+    }
+  }
+}
+
+provider "oci" {}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "server-public-ip" {
+  value = oci_core_instance.single_node_k8s.public_ip
+}

--- a/terraform/setup-server.sh
+++ b/terraform/setup-server.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# setup-server.sh is meant to provision a single-node kubernetes cluster and a postgres instance
+# on an ubuntu VM.
+
+
+# allow TCP traffic in for kubernetes, mqtt, and postgres
+iptables -I INPUT 6 -p tcp --dport 6443 -j ACCEPT # k8s
+# iptables -I INPUT 6 -p tcp --dport 1883 -j ACCEPT # mqtt - uncomment when we're ready to accept ingest traffic
+netfilter-persistent save
+
+# install postgres
+sudo apt install -y curl ca-certificates
+sudo install -d /usr/share/postgresql-common/pgdg
+sudo curl -fsSLo /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc
+
+sudo apt install -y gnupg postgresql-common apt-transport-https lsb-release wget
+sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -v 18
+
+# timescale DB
+echo "deb https://packagecloud.io/timescale/timescaledb/ubuntu/ $(lsb_release -c -s) main" | sudo tee /etc/apt/sources.list.d/timescaledb.list
+wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/timescaledb.gpg
+sudo apt update && sudo apt install -y timescaledb-2-postgresql-18 postgresql-client-18
+
+# Configure Postgres to accept connections from the internal K3s network interface
+echo "listen_addresses = '*'" >> /etc/postgresql/18/main/postgresql.conf
+echo "host all all 10.0.0.0/16 md5" >> /etc/postgresql/18/main/pg_hba.conf
+sudo timescaledb-tune --quiet --yes
+sudo systemctl restart postgresql
+
+# install kubernetes
+export PUBLIC_IP=$(curl -s ifconfig.me | tr -d '\r\n')
+# we need this for the generated certificate to include the public IP of the VM, which we needed to
+# run kubectl remotely against the server. In hindsight, I don't know why we should
+# need this; why not simply copy the manifests to the server and apply them locally? I suppose this will
+# be better if we add more nodes to our cluster, but we need to copy /etc/rancher/k3s/k3s.yaml to our workstation
+# and update the `server` part either way, so we're not going to be able to
+mkdir -p /etc/rancher/k3s
+cat <<EOF |sudo tee /etc/rancher/k3s/config.yaml
+write-kubeconfig-mode: "0644"
+tls-san:
+  - "${PUBLIC_IP}"
+cluster-init: true
+EOF
+# k3s: a small, low-memory distribution of k8s
+curl -sfL https://get.k3s.io | sh -s -
+
+kubectl create namespace formulatel

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,22 @@
+variable "compartment_ocid" {
+  type = string
+  description = "ID of the compartment to deploy these resources in"
+}
+
+variable "availability_domain" {
+  type = string
+  description = "based on the region being deployed into. `oci iam availability-domain list` will list ADs"
+}
+
+variable "home_ip" {
+  type = string
+  description = "an IPv4 address to allow SSH traffic from"
+}
+
+variable "ubuntu_arm_image_ocid" {
+  type = string
+  description = "ID of the ubuntu image to use"
+  # ID of the VM image for Ubuntu `24.04-Minimal-aarch64-2026.04.30-1`, the latest minimal Ubuntu image
+  # available for ARM64 at the time of writing
+  default = "ocid1.image.oc1.ca-montreal-1.aaaaaaaaavxe7ctjwec2f6pbyuj6vfxuncmeh4dv57sx6r2mqbuvf7zklmya"
+}

--- a/terraform/vars/.gitkeep
+++ b/terraform/vars/.gitkeep
@@ -1,0 +1,3 @@
+# deploy to your own tenancy
+
+Use this folder to define the `tfvars` for your environment, or possibly think of a better way to store the secrets we don't want to commit


### PR DESCRIPTION
This is pretty neat: turns out Oracle's cloud has a very generous free tier for ARM64 CPUs, enough to run 4 vCPUs and 24GB of memory with 200GB of block storage. This should be plenty to demo `formulatel` as a service, even if it only supports a few concurrent users.

This PR adds a build for ARM64 images and the terraform that I've deployed so far for our single-node k8s/postgres instance. The plan right now is to install [postgres+timescaledb](https://www.tigerdata.com/docs/get-started/choose-your-path/install-timescaledb#tab=ubuntu) and [k3s](https://github.com/k3s-io/k3s/) on the same machine and use `kubectl` from my workstation to install the rest of `formulatel`.

If that actually works, maybe we'll look at splitting into two instances.

Replaces #25 