### PR TITLE
feat: add web ingress and SSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ captured_packets/
 *.tfvars
 out/
 formulatel/cmd/decode/
+# ignore chart dependencies that we download with `helm dependency build <>`
+kubernetes/charts/**/*.tgz
 *.out
 coverage.*
 sandbox.tfvars

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -2,6 +2,16 @@
 
 This document is very rough and contains some of the manual setup required for the shared postgres/kubernetes node that I wasn't able to script. It's basically creating a password for the `postgres` role and adding a secret to kubernetes
 
+## download the kubeconfig
+
+After the node has been provisioned and you can access it via SSH, use `scp` to download the `kubeconfig` for the server and update the context name, server-name, and user:
+
+```bash
+ssh formulatel.oci "sudo cat /etc/rancher/k3s/k3s.yaml" > ~/.kube/formulatel-staging-config
+```
+
+You can update your `KUBECONFIG` envar to include the path to the new file. Run `kubectl config get-contexts` to show your available contexts.
+
 ## set the `postgres` user password
 
 After postgres is installed on the postgres/k8s VM, run `sudo -u postgres psql` to launch login to the DB and `\password` to set the password for the `postgres` user. You will need to create a secret in Kubernetes for the db-migrate and persist pods to be able to login to the DB.
@@ -18,11 +28,37 @@ kubectl create secret generic formulatel-db-secrets --from-literal='username=for
 
 **Note**: The `10.0.1.38` comes from k3s; it is the IP of the default CNI that gets setup. If your node isn't using k3s, that IP might not make sense.
 
+## install grafana
+
+Use `helm` to install Grafana, replacing the context and namespace with your own:
+
+```bash
+helm --kube-context formulatel-staging install grafana oci://ghcr.io/grafana-community/helm-charts/grafana --namespace formulatel --values=kubernetes/config/staging/grafana-values.yml
+```
+
+## install `mosquitto` MQTT broker:
+
+**Note: This chart is archived and should be updated**
+
+```bash
+helm --kube-context formulatel-staging --namespace formulatel install mosquitto k8s-at-home/mosquitto
+```
+
+## install formulatel
+
+Use the included chart to install `persist` and `db-migrate`
+
+```bash
+helm --kube-context formulatel-staging --namespace formulatel install formulatel ./kubernetes/charts/formulatel --values=./kubernetes/charts/formulatel/values.yaml
+```
+
+To update the running service, use `helm upgrade`
+
 ## configure Grafana datasources
 
 Since we can't exactly store passwords in plaintext, the Grafana values don't have the datasources like postgres setup automatically like they do when we `tilt up` locally. Log in to Grafana and setup the data sources manually.
 
-## forward ports
+### (optional) forward ports
 
 For local testing before setting up any DNS records, you will have to forward the Grafana and mosquitto ports:
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -28,16 +28,26 @@ kubectl create secret generic formulatel-db-secrets --from-literal='username=for
 
 **Note**: The `10.0.1.38` comes from k3s; it is the IP of the default CNI that gets setup. If your node isn't using k3s, that IP might not make sense.
 
+## install cert-manager
+
+`cert-manager` gives us a way to create self-signed SSL certificates. It needs to be installed cluster-wide in its own namespace:
+
+```bash
+helm --kube-context formulatel-staging install cert-manager oci://quay.io/jetstack/charts/cert-manager --namespace cert-manager --create-namespace --values=./config/staging/cert-manager-values.yaml --version=v1.20.3
+# update with:
+# helm --kube-context formulatel-staging upgrade cert-manager oci://quay.io/jetstack/charts/cert-manager --namespace=cert-manager --values=./config/staging/cert-manager-values.yaml
+```
+
 ## install formulatel
 
 Use the included chart to install `mqtt`, `grafana`, `persist` and `db-migrate`
 
 ```bash
 helm dependency build kubernetes/charts/formulatel
-helm --kube-context formulatel-staging --namespace formulatel install formulatel ./kubernetes/charts/formulatel --values=./kubernetes/charts/formulatel/values.yaml
+helm --kube-context formulatel-staging --namespace formulatel install formulatel ./charts/formulatel --values=./charts/formulatel/values.yaml
 ```
 
-To update the running service, use `helm upgrade`
+To update the running service, use `helm upgrade`. Remember to run `helm dependency update kubernetes/charts/formulatel` if you add dependencies to Chart.yaml
 
 ## configure Grafana datasources
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -28,27 +28,12 @@ kubectl create secret generic formulatel-db-secrets --from-literal='username=for
 
 **Note**: The `10.0.1.38` comes from k3s; it is the IP of the default CNI that gets setup. If your node isn't using k3s, that IP might not make sense.
 
-## install grafana
-
-Use `helm` to install Grafana, replacing the context and namespace with your own:
-
-```bash
-helm --kube-context formulatel-staging install grafana oci://ghcr.io/grafana-community/helm-charts/grafana --namespace formulatel --values=kubernetes/config/staging/grafana-values.yml
-```
-
-## install `mosquitto` MQTT broker:
-
-**Note: This chart is archived and should be updated**
-
-```bash
-helm --kube-context formulatel-staging --namespace formulatel install mosquitto k8s-at-home/mosquitto
-```
-
 ## install formulatel
 
-Use the included chart to install `persist` and `db-migrate`
+Use the included chart to install `mqtt`, `grafana`, `persist` and `db-migrate`
 
 ```bash
+helm dependency build kubernetes/charts/formulatel
 helm --kube-context formulatel-staging --namespace formulatel install formulatel ./kubernetes/charts/formulatel --values=./kubernetes/charts/formulatel/values.yaml
 ```
 
@@ -69,6 +54,13 @@ kubectl --namespace formulatel port-forward $POD_NAME 1883|3000
 ## start ingest
 
 Make sure to set the MQTT_BROKER envar before running ingest to point to the remote MQTT broker
+
+**With DNS**:
+```bash
+export MQTT_BROKER='tcp://mqtt.formula.tel:1883'
+```
+
+**With Port-Forwarding**:
 
 ```bash
 export MQTT_BROKER='tcp://127.0.0.1:1883'

--- a/kubernetes/charts/formulatel/Chart.lock
+++ b/kubernetes/charts/formulatel/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: mosquitto
+  repository: https://bdclark.github.io/helm-charts
+  version: 0.6.1
+- name: grafana
+  repository: oci://ghcr.io/grafana-community/helm-charts
+  version: 12.7.2
+digest: sha256:a6fde654b1643ee6330bef17ec527b7e3a565f5364f1ef5a85b542b44420d492
+generated: "2026-07-02T11:59:57.561489835-03:00"

--- a/kubernetes/charts/formulatel/Chart.lock
+++ b/kubernetes/charts/formulatel/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: oci://ghcr.io/grafana-community/helm-charts
   version: 12.7.2
 digest: sha256:a6fde654b1643ee6330bef17ec527b7e3a565f5364f1ef5a85b542b44420d492
-generated: "2026-07-02T11:59:57.561489835-03:00"
+generated: "2026-07-02T15:16:13.355105634-03:00"

--- a/kubernetes/charts/formulatel/Chart.yaml
+++ b/kubernetes/charts/formulatel/Chart.yaml
@@ -2,5 +2,12 @@ apiVersion: v2
 name: formulatel-app
 description: A Helm chart for the Formula 1 telemetry project (persist, migrate_job)
 type: application
-version: 0.2.0
-appVersion: "1.0"
+version: 0.3.0
+appVersion: "0.1.0"
+dependencies:
+  - name: mosquitto
+    version: 0.6.1
+    repository: https://bdclark.github.io/helm-charts
+  - name: grafana
+    version: 12.7.2
+    repository: oci://ghcr.io/grafana-community/helm-charts

--- a/kubernetes/charts/formulatel/Chart.yaml
+++ b/kubernetes/charts/formulatel/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: formulatel-app
 description: A Helm chart for the Formula 1 telemetry project (persist, migrate_job)
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.0"

--- a/kubernetes/charts/formulatel/templates/cluster_issuer.yaml
+++ b/kubernetes/charts/formulatel/templates/cluster_issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: {{ include "formulatel.fullname" . }}-letsencrypt-issuer
+spec:
+  acme:
+    email: {{ .Values.letsencrypt.email }}
+    server: {{ .Values.letsencrypt.server }}
+    privateKeySecretRef:
+      name: {{ .Values.letsencrypt.privateKeySecretRef }}
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: traefik

--- a/kubernetes/charts/formulatel/templates/grafana_ingress.yaml
+++ b/kubernetes/charts/formulatel/templates/grafana_ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "formulatel.fullname" . }}-grafana-ingress
+  namespace: {{ .Values.global.namespace }}
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: {{ .Values.grafana.hostname }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.grafana.service_name }}
+                port:
+                  number: {{ .Values.grafana.port }}

--- a/kubernetes/charts/formulatel/templates/grafana_ingress.yaml
+++ b/kubernetes/charts/formulatel/templates/grafana_ingress.yaml
@@ -1,10 +1,29 @@
+# this defines a Middleware that we "attach" to our Ingress via a label. It's used to redirect
+# http->https
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-https
+  namespace: {{ .Values.global.namespace }}
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "formulatel.fullname" . }}-grafana-ingress
   namespace: {{ .Values.global.namespace }}
+  annotations:
+    cert-manager.io/cluster-issuer: {{ include "formulatel.fullname" . }}-letsencrypt-issuer
+    traefik.ingress.kubernetes.io/router.middlewares: formulatel-redirect-https@kubernetescrd
 spec:
   ingressClassName: traefik
+  tls:
+    - hosts:
+        - {{ .Values.grafana_ingress.hostname }}
+      secretName: grafana-tls-cert
   rules:
     - host: {{ .Values.grafana_ingress.hostname }}
       http:

--- a/kubernetes/charts/formulatel/templates/grafana_ingress.yaml
+++ b/kubernetes/charts/formulatel/templates/grafana_ingress.yaml
@@ -6,13 +6,13 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-    - host: {{ .Values.grafana.hostname }}
+    - host: {{ .Values.grafana_ingress.hostname }}
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: {{ .Values.grafana.service_name }}
+                name: {{ .Values.grafana_ingress.service_name }}
                 port:
-                  number: {{ .Values.grafana.port }}
+                  number: {{ .Values.grafana_ingress.port }}

--- a/kubernetes/charts/formulatel/templates/migrate.yaml
+++ b/kubernetes/charts/formulatel/templates/migrate.yaml
@@ -40,4 +40,3 @@ spec:
         - name: PG_DB
           value: {{ .Values.db.name }}
       restartPolicy: Never
-  backOffLimit: 3

--- a/kubernetes/charts/formulatel/templates/migrate.yaml
+++ b/kubernetes/charts/formulatel/templates/migrate.yaml
@@ -14,7 +14,7 @@ spec:
           - "-path"
           - "migrations"
           - "-database"
-          - "postgres://$(PGHOST):$(PGPORT)/{{ .Values.db.name }}?sslmode=disable" # TODO: sslmode=enable maybe?
+          - "postgres://$(PGHOST):$(PGPORT)/{{ .Values.db.name }}?sslmode=disable"
           - "up"
         env:
         - name: PGUSER

--- a/kubernetes/charts/formulatel/templates/migrate.yaml
+++ b/kubernetes/charts/formulatel/templates/migrate.yaml
@@ -14,28 +14,28 @@ spec:
           - "-path"
           - "migrations"
           - "-database"
-          - "postgres://$(PGHOST):$(PGPORT)/{{ .Values.db.name }}?sslmode=disable"
+          - "postgres://$(PGHOST):$(PGPORT)/{{ .Values.db.name }}?sslmode=disable" # TODO: sslmode=enable maybe?
           - "up"
         env:
         - name: PGUSER
           valueFrom:
             secretKeyRef:
-              name: formulatel-db-secrets
+              name: {{ .Values.migrate.db_secret_name }}
               key: username
         - name: PGPASSWORD
           valueFrom:
             secretKeyRef:
-              name: formulatel-db-secrets
+              name: {{ .Values.migrate.db_secret_name }}
               key: password
         - name: PGHOST
           valueFrom:
             secretKeyRef:
-              name: formulatel-db-secrets
+              name: {{ .Values.migrate.db_secret_name }}
               key: host
         - name: PGPORT
           valueFrom:
             secretKeyRef:
-              name: formulatel-db-secrets
+              name: {{ .Values.migrate.db_secret_name }}
               key: port
         - name: PG_DB
           value: {{ .Values.db.name }}

--- a/kubernetes/charts/formulatel/values.yaml
+++ b/kubernetes/charts/formulatel/values.yaml
@@ -21,6 +21,13 @@ migrate:
   image: ghcr.io/isnor/formulatel/timescaledb-migrations
   tag: main
 
+# grafana - sets up an Ingress to allow web traffic into an existing Grafana service running in the cluster
+# TODO: how heavily does this rely on traefik?
+grafana:
+  hostname: dashboard.formula.tel # host to route requests from
+  port: 80 # port that Grafana exposes
+  service_name: grafana # name of the grafana service deployed in the cluster
+
 # configuration values used in multiple templates
 # db values
 db:

--- a/kubernetes/charts/formulatel/values.yaml
+++ b/kubernetes/charts/formulatel/values.yaml
@@ -18,8 +18,21 @@ persist:
 # db-migrate
 migrate:
   enabled: true
+  db_secret_name: formulatel-db-secrets
   image: ghcr.io/isnor/formulatel/timescaledb-migrations
   tag: main
+
+# configuration values used in multiple templates
+# db values
+db:
+  name: postgres
+
+letsencrypt:
+  email: isnor.james@gmail.com
+  server: https://acme-v02.api.letsencrypt.org/directory
+  privateKeySecretRef: letsencrypt-prod-account-key
+
+# sub-chart values
 
 grafana:
   plugins:
@@ -46,8 +59,7 @@ grafana:
             clientID: formulatel_grafana
             isDefault: true
 
-# grafana - sets up an Ingress to allow web traffic into an existing Grafana service running in the cluster
-# TODO: how heavily does this rely on traefik?
+# grafana - sets up an Ingress to allow web traffic into our `formulatel-grafana` service
 grafana_ingress:
   hostname: dashboard.formula.tel # host to route requests from
   port: 80 # port that Grafana exposes
@@ -57,8 +69,3 @@ grafana_ingress:
 mosquitto:
   service:
     type: LoadBalancer
-
-# configuration values used in multiple templates
-# db values
-db:
-  name: postgres

--- a/kubernetes/charts/formulatel/values.yaml
+++ b/kubernetes/charts/formulatel/values.yaml
@@ -13,7 +13,7 @@ persist:
   image: ghcr.io/isnor/formulatel/persist
   tag: main
   replicas: 1
-  mqtt_broker: 'tcp://mosquitto:1883' # address to the MQTT broker that persist talks to
+  mqtt_broker: 'tcp://formulatel-mosquitto:1883' # address to the MQTT broker that persist talks to
 
 # db-migrate
 migrate:
@@ -21,12 +21,42 @@ migrate:
   image: ghcr.io/isnor/formulatel/timescaledb-migrations
   tag: main
 
+grafana:
+  plugins:
+    - grafana-mqtt-datasource
+
+  persistence:
+    enabled: true
+
+  # creates the admin user using an existing secret
+  admin:
+    existingSecret: "formulatel-grafana-admin"
+    userKey: username
+    passwordKey: password
+
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: formulatel_mqtt
+          type: grafana-mqtt-datasource
+          jsonData:
+            uri: "tcp://formulatel-mosquitto:1883"
+            tlsAuth: false
+            clientID: formulatel_grafana
+            isDefault: true
+
 # grafana - sets up an Ingress to allow web traffic into an existing Grafana service running in the cluster
 # TODO: how heavily does this rely on traefik?
-grafana:
+grafana_ingress:
   hostname: dashboard.formula.tel # host to route requests from
   port: 80 # port that Grafana exposes
-  service_name: grafana # name of the grafana service deployed in the cluster
+  service_name: formulatel-grafana # name of the grafana service deployed in the cluster
+
+# mosquitto config - these values are passed to the `mosquitto` chart
+mosquitto:
+  service:
+    type: LoadBalancer
 
 # configuration values used in multiple templates
 # db values

--- a/kubernetes/config/dashboards/dashboard-static.json
+++ b/kubernetes/config/dashboards/dashboard-static.json
@@ -46,7 +46,7 @@
               "group": "grafana-postgresql-datasource",
               "version": "v0",
               "datasource": {
-                "name": "P7651987DC94FAF0B"
+                "name": "bfqxwocqg2ewwd"
               },
               "spec": {
                 "dataset": "postgres",
@@ -117,7 +117,7 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "P7651987DC94FAF0B"
+                          "name": "bfqxwocqg2ewwd"
                         },
                         "spec": {
                           "dataset": "postgres",
@@ -300,7 +300,7 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "P7651987DC94FAF0B"
+                          "name": "bfqxwocqg2ewwd"
                         },
                         "spec": {
                           "dataset": "postgres",
@@ -415,7 +415,7 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "P7651987DC94FAF0B"
+                          "name": "bfqxwocqg2ewwd"
                         },
                         "spec": {
                           "dataset": "postgres",
@@ -602,7 +602,7 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "P7651987DC94FAF0B"
+                          "name": "bfqxwocqg2ewwd"
                         },
                         "spec": {
                           "dataset": "postgres",
@@ -807,7 +807,7 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "P7651987DC94FAF0B"
+                          "name": "bfqxwocqg2ewwd"
                         },
                         "spec": {
                           "dataset": "postgres",
@@ -1008,7 +1008,7 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "P7651987DC94FAF0B"
+                          "name": "bfqxwocqg2ewwd"
                         },
                         "spec": {
                           "dataset": "postgres",
@@ -1205,7 +1205,7 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "P7651987DC94FAF0B"
+                          "name": "bfqxwocqg2ewwd"
                         },
                         "spec": {
                           "dataset": "postgres",
@@ -1420,7 +1420,7 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "P7651987DC94FAF0B"
+                          "name": "bfqxwocqg2ewwd"
                         },
                         "spec": {
                           "dataset": "postgres",
@@ -1607,7 +1607,7 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "P7651987DC94FAF0B"
+                          "name": "bfqxwocqg2ewwd"
                         },
                         "spec": {
                           "dataset": "postgres",
@@ -1704,7 +1704,7 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "P7651987DC94FAF0B"
+                          "name": "bfqxwocqg2ewwd"
                         },
                         "spec": {
                           "dataset": "postgres",

--- a/kubernetes/config/staging/cert-manager-values.yaml
+++ b/kubernetes/config/staging/cert-manager-values.yaml
@@ -1,0 +1,4 @@
+crds:
+  enabled: true
+prometheus:
+  enabled: false

--- a/kubernetes/migrate-job.yml
+++ b/kubernetes/migrate-job.yml
@@ -20,4 +20,3 @@ spec:
         - name: PG_DB
           value: 'postgres'
       restartPolicy: Never
-  backOffLimit: 3

--- a/terraform/k8s_server.tf
+++ b/terraform/k8s_server.tf
@@ -74,7 +74,7 @@ resource "oci_core_network_security_group_security_rule" "grafana_http_rule" {
   network_security_group_id = oci_core_network_security_group.vm_nsg.id
   direction                 = "INGRESS"
   protocol                  = "6" # TCP
-  source                    = "${var.home_ip}/32"
+  source                    = "0.0.0.0/0"
   source_type               = "CIDR_BLOCK"
   tcp_options {
     destination_port_range {
@@ -88,7 +88,7 @@ resource "oci_core_network_security_group_security_rule" "grafana_https_rule" {
   network_security_group_id = oci_core_network_security_group.vm_nsg.id
   direction                 = "INGRESS"
   protocol                  = "6" # TCP
-  source                    = "${var.home_ip}/32"
+  source                    = "0.0.0.0/0"
   source_type               = "CIDR_BLOCK"
   tcp_options {
     destination_port_range {

--- a/terraform/k8s_server.tf
+++ b/terraform/k8s_server.tf
@@ -69,7 +69,36 @@ resource "oci_core_network_security_group_security_rule" "k8s_rule" {
   }
 }
 
-# Open MQTT (1883) to the world
+# web ports for Grafana
+resource "oci_core_network_security_group_security_rule" "grafana_http_rule" {
+  network_security_group_id = oci_core_network_security_group.vm_nsg.id
+  direction                 = "INGRESS"
+  protocol                  = "6" # TCP
+  source                    = "${var.home_ip}/32"
+  source_type               = "CIDR_BLOCK"
+  tcp_options {
+    destination_port_range {
+      min = 80
+      max = 80
+    }
+  }
+}
+
+resource "oci_core_network_security_group_security_rule" "grafana_https_rule" {
+  network_security_group_id = oci_core_network_security_group.vm_nsg.id
+  direction                 = "INGRESS"
+  protocol                  = "6" # TCP
+  source                    = "${var.home_ip}/32"
+  source_type               = "CIDR_BLOCK"
+  tcp_options {
+    destination_port_range {
+      min = 443
+      max = 443
+    }
+  }
+}
+
+# MQTT port
 # TODO: restrict this to some list of CIDR blocks instead of the entire world / single IP
 resource "oci_core_network_security_group_security_rule" "mqtt_rule" {
   network_security_group_id = oci_core_network_security_group.vm_nsg.id

--- a/terraform/k8s_server.tf
+++ b/terraform/k8s_server.tf
@@ -39,19 +39,17 @@ resource "oci_core_network_security_group" "vm_nsg" {
   display_name   = "formulatel-security-group"
 }
 
-# TODO: remove the ssh and k8s rule, use tailscale instead
-
-# Restrict SSH (22) to a specific IP address
-resource "oci_core_network_security_group_security_rule" "ssh_rule" {
+# allow all UDP traffic on a specific port for a mesh network using tailscale
+resource "oci_core_network_security_group_security_rule" "tailscale_rule" {
   network_security_group_id = oci_core_network_security_group.vm_nsg.id
   direction                 = "INGRESS"
-  protocol                  = "6" # TCP
-  source                    = "${var.home_ip}/32"
+  protocol                  = "17" # UDP
+  source                    = "0.0.0.0/0"
   source_type               = "CIDR_BLOCK"
-  tcp_options {
+  udp_options {
     destination_port_range {
-      min = 22
-      max = 22
+      min = 41641
+      max = 41641
     }
   }
 }
@@ -72,7 +70,7 @@ resource "oci_core_network_security_group_security_rule" "k8s_rule" {
 }
 
 # Open MQTT (1883) to the world
-# TODO: restrict this to some list of NA CIDR blocks instead of the entire world.
+# TODO: restrict this to some list of CIDR blocks instead of the entire world / single IP
 resource "oci_core_network_security_group_security_rule" "mqtt_rule" {
   network_security_group_id = oci_core_network_security_group.vm_nsg.id
   direction                 = "INGRESS"

--- a/terraform/setup-server.sh
+++ b/terraform/setup-server.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
-# TODO: this script routinely fails to execute properly via cloud-init because `apt` fails sometimes,
-# but I don't know why
 # setup-server.sh is meant to provision a single-node kubernetes cluster and a postgres instance
 # on an ubuntu VM.
 
+# TODO: this script routinely fails to execute properly via cloud-init because `apt` fails sometimes,
+# but I don't know why
 
 # allow TCP traffic in for kubernetes, mqtt, and postgres
 # accept all traffic on port 6443 - probably a bad idea, restrict to a CIDR. the reason we have this at all
 # is so the admin can run kubectl from their workstation instead of logging into the box
 iptables -I INPUT 6 -p tcp --dport 6443 -j ACCEPT
 iptables -I INPUT -s 10.42.0.0/16 -j ACCEPT # accept all traffic from the local kubernetes cluster
-# iptables -I INPUT 6 -p tcp --dport 1883 -j ACCEPT # mqtt - uncomment when we're ready to accept ingest traffic
+iptables -I INPUT 6 -p tcp --dport 1883 -j ACCEPT # mqtt
+iptables -I INPUT -p tcp --dport 80 -j ACCEPT # grafana
+iptables -I INPUT -p tcp --dport 443 -j ACCEPT # grafana
 netfilter-persistent save
 
 # install postgres
@@ -56,3 +58,7 @@ EOF
 curl -sfL https://get.k3s.io | sh -s -
 
 kubectl create namespace formulatel
+
+# tailscale
+# TODO: see https://tailscale.com/docs/features/access-control/auth-keys to automate this
+# curl -fsSL https://tailscale.com/install.sh | sh


### PR DESCRIPTION
This PR is the first one in which we've started using the `formula.tel` domain, and it marks the first publicly available version of the formulatel cloud service - albeit view-only for authenticated users (that I created) without any sign-up functionality. The telemetry channel port is still closed to the world.

This PR focused a lot more on the devops side of this project: installing `cert-manager` isn't really in-scope for formulatel, but I wanted to be sure it's easy to setup another node and for others to setup their own nodes if they want, so some of that setup is documented in the `kubernetes/README.md`.

The chart definitely still needs more work before being packaged for others to use; the ClusterIssuer in particular is not something that should be in the chart.