### PR TITLE
feat: tenant dashboards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ migrate:
 	migrate -path ./migrations -database postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable up
 
 live-dashboard:
-	curl -v -H 'Content-Type: application/json' --data @kubernetes/config/dashboards/dashboard-live.json localhost:3000/api/dashboards/db
+	curl -v -u admin:$(shell kubectl get secret --namespace=formulatel formulatel-grafana -o yaml | yq -r '.data["admin-password"]' | base64 -d) -H 'Content-Type: application/json' --data @kubernetes/config/dashboards/dashboard-live.json localhost:3000/api/dashboards/db
 
 static-dashboard:
-	curl -v -H 'Content-Type: application/json' --data @kubernetes/config/dashboards/dashboard-static.json localhost:3000/api/dashboards/db
+	curl -v -u admin:$(shell kubectl get secret --namespace=formulatel formulatel-grafana -o yaml | yq -r '.data["admin-password"]' | base64 -d) -H 'Content-Type: application/json' --data @kubernetes/config/dashboards/dashboard-static.json localhost:3000/api/dashboards/db

--- a/formulatel/cmd/admin/main.go
+++ b/formulatel/cmd/admin/main.go
@@ -94,6 +94,14 @@ func main() {
 					// DeleteUser(),
 				},
 			},
+			{
+				Name: "dashboard",
+				Usage: "dashboard management operations",
+				Category: "dashboards",
+				Commands: []*cli.Command{
+					CreateDashboard(),
+				},
+			},
 		},
 	}
 

--- a/formulatel/cmd/admin/tenants.go
+++ b/formulatel/cmd/admin/tenants.go
@@ -103,10 +103,9 @@ func (t *TenantManager) CreateOrg(ctx context.Context, request CreateOrgRequest)
 		return fmt.Errorf("failed to create tenant row: %w", err)
 	}
 
-	// we're creating a role per-org to facilitate row-level-security
-	// TODO: what if slug has weird characters? It must be sanitized
-	tenantRole := fmt.Sprintf("tenant_%s", request.Slug)
-	pgRolePassword, err := password.Generate(32, 4, 4, false, true)
+	// we're creating a role per-org
+	tenantRole := fmt.Sprintf("tenant_%d", createdOrgID)
+	pgRolePassword, err := password.Generate(32, 4, 0, false, true)
 	if err != nil {
 		return fmt.Errorf("failed generating password :( - %w", err)
 	}
@@ -200,7 +199,7 @@ func (t *TenantManager) CreateOrg(ctx context.Context, request CreateOrgRequest)
 			INSERT INTO auth.mqtt_acls (account_id, topic, access_level)
 			SELECT
 					id,
-					'formulatel/' || $1 || '/#',
+					'formulatel/+/' || $1 || '/#',
 					1
 			FROM new_account;
 			`,
@@ -252,7 +251,7 @@ func (t *TenantManager) CreateOrg(ctx context.Context, request CreateOrgRequest)
 
 // CreateUser adds a row to `auth.accounts` and a corresponding read/write ACL to `auth.mqtt_acls`
 func (t *TenantManager) CreateUser(ctx context.Context, request CreateUserRequest) (*CreateUserResponse, error) {
-	userToken, err := password.Generate(64, 4, 4, false, true)
+	userToken, err := password.Generate(64, 4, 0, false, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed generating password :( - %w", err)
 	}
@@ -275,11 +274,15 @@ func (t *TenantManager) CreateUser(ctx context.Context, request CreateUserReques
 					INSERT INTO auth.accounts (grafana_org_id, username, password_hash, is_human)
 					VALUES ($1, $2, %s, true)
 					RETURNING id
+			),
+			new_user AS (
+				INSERT INTO telemetry.users (id, tenant_id, username)
+					SELECT id, $1, $2 FROM new_account
 			)
 			INSERT INTO auth.mqtt_acls (account_id, topic, access_level)
 			SELECT
 					id,
-					'formulatel/' || $1 || '/' || $2 || '/#',
+					'formulatel/+/' || $1 || '/' || $2 || '/#',
 					3
 			FROM new_account;
 			`,

--- a/formulatel/cmd/admin/tenants.go
+++ b/formulatel/cmd/admin/tenants.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/jackc/pgx/v5"
@@ -12,6 +14,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	grafanasdk "github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/grafana/grafana-openapi-client-go/client/dashboards"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/sethvargo/go-password/password"
 )
@@ -44,8 +47,17 @@ type CreateUserRequest struct {
 	Transaction pgx.Tx
 }
 
+type CreateDashboardRequest struct {
+	TenantID      int64
+	DashboardFile string
+}
+
 type CreateUserResponse struct {
 	Token string
+}
+
+type CreateDashboardResponse struct {
+	ID int64
 }
 
 // CreateOrg uses the Grafana SDK to create a new Org
@@ -166,7 +178,6 @@ func (t *TenantManager) CreateOrg(ctx context.Context, request CreateOrgRequest)
 		JSONData: map[string]any{
 			"uri":      request.MQTTURI,
 			"tlsAuth":  false,
-			"clientID": fmt.Sprintf("formulatel_grafana_%d", createdOrgID),
 			"username": tenantRole,
 		},
 
@@ -212,7 +223,6 @@ func (t *TenantManager) CreateOrg(ctx context.Context, request CreateOrgRequest)
 		return fmt.Errorf("failed to register account and MQTT ACL: %w", err)
 	}
 
-	// TODO: maybe this should happen in the `tenant user create` command or something
 	// create an "account" for the telemetry stream
 	userName := request.Username
 	user, err := t.CreateUser(ctx, CreateUserRequest{
@@ -308,6 +318,42 @@ func (t *TenantManager) CreateUser(ctx context.Context, request CreateUserReques
 	return &CreateUserResponse{
 		Token: userToken,
 	}, nil
+}
+
+func (t *TenantManager) CreateDashboard(ctx context.Context, request CreateDashboardRequest) (*CreateDashboardResponse, error) {
+	rawJSON, err := os.ReadFile(request.DashboardFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading dashboard JSON %w:", err)
+	}
+
+	var dashboardMap map[string]any
+	if err := json.Unmarshal(rawJSON, &dashboardMap); err != nil {
+		return nil, fmt.Errorf("invalid dashboard JSON %w:", err)
+	}
+
+	params := dashboards.NewPostDashboardParamsWithContext(context.Background()).
+		WithBody(&models.SaveDashboardCommand{
+			Dashboard: dashboardMap["dashboard"],
+			Overwrite: true,
+		})
+
+	resp, err := t.Grafana.WithOrgID(request.TenantID).Dashboards.PostDashboardWithParams(params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dashboard: %w", err)
+	}
+	if resp.IsSuccess() {
+		slog.InfoContext(ctx, "created dashboard",
+			"url", *(resp.Payload.URL),
+			"title", resp.Payload.Title,
+			"org_id", request.TenantID,
+		)
+		return &CreateDashboardResponse{
+			ID: *resp.Payload.ID,
+		}, err
+	}
+	slog.ErrorContext(ctx, "failed to create dashboard", "code", resp.Code(), "response", resp.String())
+	return nil, fmt.Errorf("failed to create dashboard")
+
 }
 
 func NewTenantManager(grafanaOpts *grafanasdk.TransportConfig, dbConnString string) (*TenantManager, error) {
@@ -440,6 +486,46 @@ func CreateUser() *cli.Command {
 				return err
 			}
 			slog.InfoContext(ctx, "✅ created user", "username", username, "token", user.Token)
+			return nil
+		},
+	}
+}
+
+func CreateDashboard() *cli.Command {
+	return &cli.Command{
+		Name: "create",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "dashboard-file",
+				Required: true,
+			},
+			&cli.IntFlag{
+				Name:     "tenant",
+				Aliases:  []string{"tid", "t", "tenant-id"},
+				Usage:    "The tenant ID to create the dashboard for",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			t, ok := ctx.Value(tenantManagerContext).(*TenantManager)
+			if !ok {
+				return fmt.Errorf("no manager setup")
+			}
+			tenantID := cmd.Int("tenant")
+			dashboardFile := cmd.String("dashboard-file")
+
+			r, err := t.CreateDashboard(ctx, CreateDashboardRequest{
+				TenantID:      int64(tenantID),
+				DashboardFile: dashboardFile,
+			})
+
+			if err != nil {
+				slog.ErrorContext(ctx, "⚠️ failed creating dashboard", "error", err)
+				return err
+			}
+
+			slog.InfoContext(ctx, "✅ created dashboard", "id", r.ID)
+
 			return nil
 		},
 	}

--- a/formulatel/cmd/ingest/main.go
+++ b/formulatel/cmd/ingest/main.go
@@ -38,7 +38,7 @@ func main() {
 	}
 	defer conn.Close()
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
+		Level: slog.LevelDebug,
 	})))
 
 	ingestConfig.VehicleDataChannel = make(chan *pb.GameTelemetry, 100)
@@ -94,11 +94,11 @@ func main() {
 	}
 	// connect each telemetry channel to an mqtt topic
 	for topic, channel := range map[string]chan *pb.GameTelemetry{
-		prefixTopic("vehicledata/f123", ingestConfig.Username, ingestConfig.TenantID):       ingestConfig.VehicleDataChannel,
-		prefixTopic("motiondata/f123", ingestConfig.Username, ingestConfig.TenantID):        ingestConfig.MotionDataChannel,
-		prefixTopic("currentlapdata/f123", ingestConfig.Username, ingestConfig.TenantID):    ingestConfig.CurrentLapDataChannel,
-		prefixTopic("laptimesdata/f123", ingestConfig.Username, ingestConfig.TenantID):      ingestConfig.LapTimesDataChannel,
-		prefixTopic("extendedwheeldata/f123", ingestConfig.Username, ingestConfig.TenantID): ingestConfig.ExtendedWheelDataChannel,
+		prefixTopic("vehicledata", ingestConfig.Username, ingestConfig.TenantID):       ingestConfig.VehicleDataChannel,
+		prefixTopic("motiondata", ingestConfig.Username, ingestConfig.TenantID):        ingestConfig.MotionDataChannel,
+		prefixTopic("currentlapdata", ingestConfig.Username, ingestConfig.TenantID):    ingestConfig.CurrentLapDataChannel,
+		prefixTopic("laptimesdata", ingestConfig.Username, ingestConfig.TenantID):      ingestConfig.LapTimesDataChannel,
+		prefixTopic("extendedwheeldata", ingestConfig.Username, ingestConfig.TenantID): ingestConfig.ExtendedWheelDataChannel,
 	} {
 		wg.Go(func() {
 			ctx, cancel := context.WithCancel(serverContext)
@@ -120,5 +120,5 @@ func main() {
 
 // prefixTopic prepends org/user to a given topic
 func prefixTopic(topic, user string, tenant int) string {
-	return fmt.Sprintf("formulatel/%d/%s/%s", tenant, user, topic)
+	return fmt.Sprintf("formulatel/f123/%d/%s/%s", tenant, user, topic)
 }

--- a/formulatel/cmd/persist/main.go
+++ b/formulatel/cmd/persist/main.go
@@ -99,8 +99,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	// subscribe to wildcard topic: formulatel/+/f123
-	subTopic := "$share/persist/formulatel/+/f123"
+	// subscribe to wildcard topic: formulatel/f123/#
+	subTopic := "$share/persist/formulatel/f123/#"
 	tracer := otel.Tracer("formulatel/persist/mqtt")
 	mqttClient.Subscribe(subTopic, 0, func(client mqtt.Client, msg mqtt.Message) {
 		msgCtx, span := tracer.Start(ctx, "mqtt.receive")

--- a/formulatel/internal/timescale/timescale_test.go
+++ b/formulatel/internal/timescale/timescale_test.go
@@ -209,6 +209,8 @@ func (mt *WithMigrationsTest) Run(t *testing.T) {
 		defer migrations.Close()
 
 		if mt.MigrationNum == 0 {
+			// TODO: maybe this wasn't such a good idea, at least not in parallel execution when one of the
+			// migrations provisions a role
 			require.NoError(t, migrations.Up())
 		} else {
 			require.NoError(t, migrations.Migrate(mt.MigrationNum))

--- a/kubernetes/charts/formulatel/Chart.yaml
+++ b/kubernetes/charts/formulatel/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: formulatel
 description: A Helm chart that provisions `formulatel-persist`, the database migrations, Grafana, and mosquitto
 type: application
-version: 0.6.0
+version: 0.7.0
 appVersion: "0.1.0"
 dependencies:
   - name: grafana

--- a/kubernetes/config/dashboards/dashboard-live.json
+++ b/kubernetes/config/dashboards/dashboard-live.json
@@ -5,7 +5,7 @@
     "metadata": {
       "name": "g88p27",
       "generation": 2,
-      "creationTimestamp": "2026-07-21T20:46:16Z",
+      "creationTimestamp": "2026-07-22T15:01:25Z",
       "labels": {},
       "annotations": {}
     },
@@ -50,7 +50,7 @@
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
                         "spec": {
-                          "topic": "formulatel/${__org.id}/${driver}/vehicledata/f123"
+                          "topic": "formulatel/+/$__org/$driver/vehicledata"
                         },
                         "labels": {
                           "grafana.app/export-label": "grafana-mqtt-datasource-1",
@@ -181,7 +181,7 @@
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
                         "spec": {
-                          "topic": "formulatel/${__org.id}/${driver}/vehicledata/f123"
+                          "topic": "formulatel/+/$__org/$driver/vehicledata"
                         },
                         "labels": {
                           "grafana.app/export-label": "grafana-mqtt-datasource-1",
@@ -298,7 +298,7 @@
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
                         "spec": {
-                          "topic": "formulatel/vehicledata/f123"
+                          "topic": "formulatel/+/$__org/$driver/vehicledata"
                         },
                         "labels": {
                           "grafana.app/export-label": "grafana-mqtt-datasource-1",
@@ -412,7 +412,7 @@
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
                         "spec": {
-                          "topic": "formulatel/vehicledata/f123"
+                          "topic": "formulatel/+/$__org/$driver/vehicledata"
                         },
                         "labels": {
                           "grafana.app/export-label": "grafana-mqtt-datasource-1",
@@ -512,7 +512,7 @@
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
                         "spec": {
-                          "topic": "formulatel/${__org.id}/${driver}/vehicledata/f123"
+                          "topic": "formulatel/+/$__org/$driver/vehicledata"
                         },
                         "labels": {
                           "grafana.app/export-label": "grafana-mqtt-datasource-1",
@@ -622,7 +622,7 @@
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
                         "spec": {
-                          "topic": "formulatel/$__org.id/$driver/motiondata/f123"
+                          "topic": "formulatel/+/$__org/$driver/motiondata"
                         },
                         "labels": {
                           "grafana.app/export-label": "grafana-mqtt-datasource-1",
@@ -772,7 +772,7 @@
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
                         "spec": {
-                          "topic": "formulatel/motiondata/f123"
+                          "topic": "formulatel/+/$__org/$driver/motiondata"
                         },
                         "labels": {
                           "grafana.app/export-label": "grafana-mqtt-datasource-1",
@@ -961,7 +961,7 @@
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
                         "spec": {
-                          "topic": "formulatel/${__org.id}/${driver}/motiondata/f123"
+                          "topic": "formulatel/+/$__org/$driver/motiondata"
                         },
                         "labels": {
                           "grafana.app/export-label": "grafana-mqtt-datasource-1",
@@ -1073,7 +1073,7 @@
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
                         "spec": {
-                          "topic": "formulatel/${__org.id}/${driver}/motiondata/f123"
+                          "topic": "formulatel/+/$__org/$driver/motiondata"
                         },
                         "labels": {
                           "grafana.app/export-label": "grafana-mqtt-datasource-1",
@@ -1185,7 +1185,7 @@
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
                         "spec": {
-                          "topic": "formulatel/f123/$__org.id/$driver/vehicledata"
+                          "topic": "formulatel/+/$__org/$driver/vehicledata"
                         },
                         "labels": {
                           "grafana.app/export-label": "grafana-mqtt-datasource-1",
@@ -1295,7 +1295,7 @@
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
                         "spec": {
-                          "topic": "formulatel/vehicledata/f123"
+                          "topic": "formulatel/+/$__org/$driver/vehicledata"
                         },
                         "labels": {
                           "grafana.app/export-label": "grafana-mqtt-datasource-1",

--- a/kubernetes/config/dashboards/dashboard-live.json
+++ b/kubernetes/config/dashboards/dashboard-live.json
@@ -4,21 +4,10 @@
     "kind": "Dashboard",
     "metadata": {
       "name": "g88p27",
-      "namespace": "default",
-      "uid": "547febe7-d326-4559-883b-dccf672e41ff",
-      "resourceVersion": "1779410140642985",
       "generation": 2,
-      "creationTimestamp": "2026-05-22T00:31:58Z",
-      "labels": {
-        "grafana.app/deprecatedInternalID": "3979018795216896"
-      },
-      "annotations": {
-        "grafana.app/createdBy": "anonymous:0",
-        "grafana.app/folder": "",
-        "grafana.app/saved-from-ui": "Grafana v13.0.1+security-01 (9bbe672d)",
-        "grafana.app/updatedBy": "anonymous:0",
-        "grafana.app/updatedTimestamp": "2026-05-22T00:35:40Z"
-      }
+      "creationTimestamp": "2026-07-21T20:46:16Z",
+      "labels": {},
+      "annotations": {}
     },
     "spec": {
       "annotations": [
@@ -29,9 +18,6 @@
               "kind": "DataQuery",
               "group": "grafana",
               "version": "v0",
-              "datasource": {
-                "name": "-- Grafana --"
-              },
               "spec": {}
             },
             "enable": true,
@@ -63,11 +49,12 @@
                         "kind": "DataQuery",
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "PAD508E29D1B5373F"
-                        },
                         "spec": {
-                          "topic": "formulatel/vehicledata/f123"
+                          "topic": "formulatel/${__org.id}/${driver}/vehicledata/f123"
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-mqtt-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-mqtt"
                         }
                       },
                       "refId": "A",
@@ -101,13 +88,14 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "bargauge",
-              "version": "13.0.1+security-01",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "displayMode": "gradient",
                   "legend": {
                     "calcs": [],
                     "displayMode": "list",
+                    "overflow": "ellipsis",
                     "placement": "bottom",
                     "showLegend": false
                   },
@@ -165,7 +153,8 @@
                     },
                     "color": {
                       "mode": "thresholds"
-                    }
+                    },
+                    "noValue": "0"
                   },
                   "overrides": []
                 }
@@ -191,11 +180,12 @@
                         "kind": "DataQuery",
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "PAD508E29D1B5373F"
-                        },
                         "spec": {
-                          "topic": "formulatel/vehicledata/f123"
+                          "topic": "formulatel/${__org.id}/${driver}/vehicledata/f123"
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-mqtt-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-mqtt"
                         }
                       },
                       "refId": "A",
@@ -231,7 +221,7 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "gauge",
-              "version": "13.0.1+security-01",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "barShape": "flat",
@@ -280,7 +270,8 @@
                           "color": "red"
                         }
                       ]
-                    }
+                    },
+                    "noValue": "0"
                   },
                   "overrides": []
                 }
@@ -306,11 +297,12 @@
                         "kind": "DataQuery",
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "PAD508E29D1B5373F"
-                        },
                         "spec": {
                           "topic": "formulatel/vehicledata/f123"
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-mqtt-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-mqtt"
                         }
                       },
                       "refId": "A",
@@ -346,7 +338,7 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "gauge",
-              "version": "13.0.1+security-01",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "barShape": "flat",
@@ -392,6 +384,7 @@
                     "color": {
                       "mode": "continuous-BlYlRd"
                     },
+                    "noValue": "0",
                     "fieldMinMax": false
                   },
                   "overrides": []
@@ -418,11 +411,12 @@
                         "kind": "DataQuery",
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "PAD508E29D1B5373F"
-                        },
                         "spec": {
                           "topic": "formulatel/vehicledata/f123"
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-mqtt-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-mqtt"
                         }
                       },
                       "refId": "A",
@@ -456,7 +450,7 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "stat",
-              "version": "13.0.1+security-01",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "colorMode": "background",
@@ -490,7 +484,8 @@
                           "color": "red"
                         }
                       ]
-                    }
+                    },
+                    "noValue": "N"
                   },
                   "overrides": []
                 }
@@ -516,11 +511,12 @@
                         "kind": "DataQuery",
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "PAD508E29D1B5373F"
-                        },
                         "spec": {
-                          "topic": "formulatel/vehicledata/f123"
+                          "topic": "formulatel/${__org.id}/${driver}/vehicledata/f123"
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-mqtt-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-mqtt"
                         }
                       },
                       "refId": "A",
@@ -554,13 +550,14 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "bargauge",
-              "version": "13.0.1+security-01",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "displayMode": "gradient",
                   "legend": {
                     "calcs": [],
                     "displayMode": "list",
+                    "overflow": "ellipsis",
                     "placement": "bottom",
                     "showLegend": false
                   },
@@ -624,11 +621,12 @@
                         "kind": "DataQuery",
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "PAD508E29D1B5373F"
-                        },
                         "spec": {
-                          "topic": "formulatel/motiondata/f123"
+                          "topic": "formulatel/$__org.id/$driver/motiondata/f123"
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-mqtt-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-mqtt"
                         }
                       },
                       "refId": "A",
@@ -668,12 +666,13 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "xychart",
-              "version": "13.0.1+security-01",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "legend": {
                     "calcs": [],
                     "displayMode": "list",
+                    "overflow": "ellipsis",
                     "placement": "bottom",
                     "showLegend": true
                   },
@@ -772,11 +771,12 @@
                         "kind": "DataQuery",
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "PAD508E29D1B5373F"
-                        },
                         "spec": {
                           "topic": "formulatel/motiondata/f123"
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-mqtt-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-mqtt"
                         }
                       },
                       "refId": "A",
@@ -855,12 +855,13 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "xychart",
-              "version": "13.0.1+security-01",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "legend": {
                     "calcs": [],
                     "displayMode": "list",
+                    "overflow": "ellipsis",
                     "placement": "bottom",
                     "showLegend": true
                   },
@@ -959,11 +960,12 @@
                         "kind": "DataQuery",
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "PAD508E29D1B5373F"
-                        },
                         "spec": {
-                          "topic": "formulatel/motiondata/f123"
+                          "topic": "formulatel/${__org.id}/${driver}/motiondata/f123"
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-mqtt-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-mqtt"
                         }
                       },
                       "refId": "A",
@@ -1000,13 +1002,14 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "bargauge",
-              "version": "13.0.1+security-01",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "displayMode": "gradient",
                   "legend": {
                     "calcs": [],
                     "displayMode": "list",
+                    "overflow": "ellipsis",
                     "placement": "bottom",
                     "showLegend": false
                   },
@@ -1042,7 +1045,8 @@
                     },
                     "color": {
                       "mode": "thresholds"
-                    }
+                    },
+                    "noValue": "1"
                   },
                   "overrides": []
                 }
@@ -1068,11 +1072,12 @@
                         "kind": "DataQuery",
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "PAD508E29D1B5373F"
-                        },
                         "spec": {
-                          "topic": "formulatel/motiondata/f123"
+                          "topic": "formulatel/${__org.id}/${driver}/motiondata/f123"
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-mqtt-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-mqtt"
                         }
                       },
                       "refId": "A",
@@ -1107,13 +1112,14 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "bargauge",
-              "version": "13.0.1+security-01",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "displayMode": "gradient",
                   "legend": {
                     "calcs": [],
                     "displayMode": "list",
+                    "overflow": "ellipsis",
                     "placement": "bottom",
                     "showLegend": false
                   },
@@ -1151,7 +1157,8 @@
                     },
                     "color": {
                       "mode": "thresholds"
-                    }
+                    },
+                    "noValue": "1"
                   },
                   "overrides": []
                 }
@@ -1177,11 +1184,12 @@
                         "kind": "DataQuery",
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "PAD508E29D1B5373F"
-                        },
                         "spec": {
-                          "topic": "formulatel/vehicledata/f123"
+                          "topic": "formulatel/f123/$__org.id/$driver/vehicledata"
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-mqtt-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-mqtt"
                         }
                       },
                       "refId": "A",
@@ -1215,13 +1223,14 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "bargauge",
-              "version": "13.0.1+security-01",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "displayMode": "gradient",
                   "legend": {
                     "calcs": [],
                     "displayMode": "list",
+                    "overflow": "ellipsis",
                     "placement": "bottom",
                     "showLegend": false
                   },
@@ -1285,11 +1294,12 @@
                         "kind": "DataQuery",
                         "group": "grafana-mqtt-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "PAD508E29D1B5373F"
-                        },
                         "spec": {
                           "topic": "formulatel/vehicledata/f123"
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-mqtt-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-mqtt"
                         }
                       },
                       "refId": "A",
@@ -1323,7 +1333,7 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "timeseries",
-              "version": "13.0.1+security-01",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "annotations": {
@@ -1333,6 +1343,8 @@
                   "legend": {
                     "calcs": [],
                     "displayMode": "hidden",
+                    "enableFacetedFilter": false,
+                    "overflow": "ellipsis",
                     "placement": "right",
                     "showLegend": false
                   },
@@ -1357,6 +1369,7 @@
                     "color": {
                       "mode": "continuous-BlYlRd"
                     },
+                    "noValue": "1",
                     "custom": {
                       "axisBorderShow": false,
                       "axisCenteredZero": false,
@@ -1608,6 +1621,134 @@
             "refresh": "onTimeRangeChanged",
             "hide": "dontHide",
             "skipUrlSync": false
+          }
+        },
+        {
+          "kind": "QueryVariable",
+          "spec": {
+            "name": "driver",
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "hide": "dontHide",
+            "refresh": "onDashboardLoad",
+            "skipUrlSync": false,
+            "query": {
+              "kind": "DataQuery",
+              "group": "grafana-postgresql-datasource",
+              "version": "v0",
+              "spec": {
+                "dataset": "postgres",
+                "editorMode": "code",
+                "format": "table",
+                "query": "SELECT distinct username FROM telemetry.users",
+                "rawQuery": true,
+                "rawSql": "SELECT distinct username FROM telemetry.users",
+                "refId": "SQLVariableQueryEditor-VariableQuery",
+                "sql": {
+                  "columns": [
+                    {
+                      "parameters": [
+                        {
+                          "name": "username",
+                          "type": "functionParameter"
+                        }
+                      ],
+                      "type": "function"
+                    }
+                  ],
+                  "groupBy": [
+                    {
+                      "property": {
+                        "type": "string"
+                      },
+                      "type": "groupBy"
+                    }
+                  ],
+                  "limit": 50,
+                  "whereJsonTree": {
+                    "children1": [
+                      {
+                        "id": "bb9ab8ab-cdef-4012-b456-719f6e24e6a1",
+                        "properties": {
+                          "field": "grafana_org_id",
+                          "fieldSrc": "field",
+                          "operator": "equal",
+                          "value": [
+                            null
+                          ],
+                          "valueError": [
+                            null
+                          ],
+                          "valueSrc": [
+                            "value"
+                          ],
+                          "valueType": [
+                            "number"
+                          ]
+                        },
+                        "type": "rule"
+                      }
+                    ],
+                    "id": "ab8a9b98-0123-4456-b89a-b19f6e2384cf",
+                    "type": "group"
+                  },
+                  "whereString": "grafana_org_id = NaN"
+                },
+                "table": "auth.accounts"
+              },
+              "labels": {
+                "grafana.app/export-label": "grafana-postgresql-datasource-1",
+                "grafana.app/export-datasource-name": "formulatel-postgresql"
+              }
+            },
+            "regex": "",
+            "regexApplyTo": "value",
+            "sort": "disabled",
+            "definition": "SELECT distinct username FROM telemetry.users",
+            "options": [],
+            "multi": false,
+            "includeAll": false,
+            "allowCustomValue": true
+          }
+        },
+        {
+          "kind": "QueryVariable",
+          "spec": {
+            "name": "tenant_id",
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "hide": "hideVariable",
+            "refresh": "onDashboardLoad",
+            "skipUrlSync": false,
+            "query": {
+              "kind": "DataQuery",
+              "group": "grafana-postgresql-datasource",
+              "version": "v0",
+              "spec": {
+                "dataset": "postgres",
+                "editorMode": "builder",
+                "format": "table",
+                "query": "",
+                "rawSql": "",
+                "refId": "SQLVariableQueryEditor-VariableQuery"
+              },
+              "labels": {
+                "grafana.app/export-label": "grafana-postgresql-datasource-1",
+                "grafana.app/export-datasource-name": "formulatel-postgresql"
+              }
+            },
+            "regex": "",
+            "regexApplyTo": "value",
+            "sort": "disabled",
+            "definition": "",
+            "options": [],
+            "multi": false,
+            "includeAll": false,
+            "allowCustomValue": true
           }
         }
       ]

--- a/kubernetes/config/dashboards/dashboard-static.json
+++ b/kubernetes/config/dashboards/dashboard-static.json
@@ -46,14 +46,14 @@
               "group": "grafana-postgresql-datasource",
               "version": "v0",
               "datasource": {
-                "name": "bfqxwocqg2ewwd"
+                "name": "ffr53wnc5ks1sf"
               },
               "spec": {
-                "dataset": "postgres",
+                "dataset": "formulatel",
                 "editorMode": "code",
                 "format": "table",
                 "rawQuery": true,
-                "rawSql": "SELECT\n  distinct current_lap_time, max(time) as time,\n  'Lap ' || lap_num - 1 || ' (' || current_lap_time || 'ms)' AS text,\n  'lap-marker' AS tags\nFROM live_lap_data\nWHERE $__timeFilter(time) AND current_lap_time > 0\ngroup by current_lap_time, lap_num\nORDER BY time ASC;",
+                "rawSql": "SELECT\n  distinct current_lap_time, max(time) as time,\n  'Lap ' || lap_num - 1 || ' (' || current_lap_time || 'ms)' AS text,\n  'lap-marker' AS tags\nFROM telemetry.live_lap_data\nWHERE $__timeFilter(time) AND current_lap_time > 0\ngroup by current_lap_time, lap_num\nORDER BY time ASC;",
                 "refId": "Anno",
                 "sql": {
                   "columns": [
@@ -117,13 +117,13 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "bfqxwocqg2ewwd"
+                          "name": "ffr53wnc5ks1sf"
                         },
                         "spec": {
-                          "dataset": "postgres",
+                          "dataset": "formulatel",
                           "editorMode": "builder",
                           "format": "time_series",
-                          "rawSql": "SELECT \"time\", speed FROM vehicle_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
+                          "rawSql": "SELECT \"time\", speed FROM telemetry.vehicle_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
                           "sql": {
                             "columns": [
                               {
@@ -300,10 +300,10 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "bfqxwocqg2ewwd"
+                          "name": "ffr53wnc5ks1sf"
                         },
                         "spec": {
-                          "dataset": "postgres",
+                          "dataset": "formulatel",
                           "editorMode": "code",
                           "format": "table",
                           "rawQuery": true,
@@ -415,13 +415,13 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "bfqxwocqg2ewwd"
+                          "name": "ffr53wnc5ks1sf"
                         },
                         "spec": {
-                          "dataset": "postgres",
+                          "dataset": "formulatel",
                           "editorMode": "builder",
                           "format": "time_series",
-                          "rawSql": "SELECT \"time\", rpm FROM vehicle_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
+                          "rawSql": "SELECT \"time\", rpm FROM telemetry.vehicle_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
                           "sql": {
                             "columns": [
                               {
@@ -602,13 +602,13 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "bfqxwocqg2ewwd"
+                          "name": "ffr53wnc5ks1sf"
                         },
                         "spec": {
-                          "dataset": "postgres",
+                          "dataset": "formulatel",
                           "editorMode": "builder",
                           "format": "time_series",
-                          "rawSql": "SELECT \"time\", gforce_lateral, gforce_longitudinal, gforce_vertical FROM motion_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
+                          "rawSql": "SELECT \"time\", gforce_lateral, gforce_longitudinal, gforce_vertical FROM telemetry.motion_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
                           "sql": {
                             "columns": [
                               {
@@ -807,13 +807,13 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "bfqxwocqg2ewwd"
+                          "name": "ffr53wnc5ks1sf"
                         },
                         "spec": {
-                          "dataset": "postgres",
+                          "dataset": "formulatel",
                           "editorMode": "builder",
                           "format": "time_series",
-                          "rawSql": "SELECT \"time\", velocity_x, velocity_y, velocity_z FROM motion_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
+                          "rawSql": "SELECT \"time\", velocity_x, velocity_y, velocity_z FROM telemetry.motion_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
                           "sql": {
                             "columns": [
                               {
@@ -1008,14 +1008,14 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "bfqxwocqg2ewwd"
+                          "name": "ffr53wnc5ks1sf"
                         },
                         "spec": {
-                          "dataset": "postgres",
+                          "dataset": "formulatel",
                           "editorMode": "code",
                           "format": "time_series",
                           "rawQuery": true,
-                          "rawSql": "SELECT \"time\", throttle, -brake as brake FROM vehicle_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
+                          "rawSql": "SELECT \"time\", throttle, -brake as brake FROM telemetry.vehicle_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
                           "sql": {
                             "columns": [
                               {
@@ -1205,13 +1205,13 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "bfqxwocqg2ewwd"
+                          "name": "ffr53wnc5ks1sf"
                         },
                         "spec": {
-                          "dataset": "postgres",
+                          "dataset": "formulatel",
                           "editorMode": "builder",
                           "format": "time_series",
-                          "rawSql": "SELECT \"time\", fl_brake_temp AS \"front left\", fr_brake_temp AS \"front right\", bl_brake_temp AS \"back left\", br_brake_temp AS \"back right\" FROM vehicle_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
+                          "rawSql": "SELECT \"time\", fl_brake_temp AS \"front left\", fr_brake_temp AS \"front right\", bl_brake_temp AS \"back left\", br_brake_temp AS \"back right\" FROM telemetry.vehicle_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
                           "sql": {
                             "columns": [
                               {
@@ -1420,13 +1420,13 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "bfqxwocqg2ewwd"
+                          "name": "ffr53wnc5ks1sf"
                         },
                         "spec": {
-                          "dataset": "postgres",
+                          "dataset": "formulatel",
                           "editorMode": "builder",
                           "format": "table",
-                          "rawSql": "SELECT \"time\", yaw FROM motion_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
+                          "rawSql": "SELECT \"time\", yaw FROM telemetry.motion_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
                           "sql": {
                             "columns": [
                               {
@@ -1607,14 +1607,14 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "bfqxwocqg2ewwd"
+                          "name": "ffr53wnc5ks1sf"
                         },
                         "spec": {
-                          "dataset": "postgres",
+                          "dataset": "formulatel",
                           "editorMode": "code",
                           "format": "table",
                           "rawQuery": true,
-                          "rawSql": "select lap_num, lap_time, sector1_time, sector2_time, sector3_time, lap_valid, sector1_valid, sector2_valid, sector3_valid from session_lap_data \nwhere cast($session_id as VARCHAR) = session_id\nand cast($driver_ID as varchar) = user_id\norder by lap_num",
+                          "rawSql": "select lap_num, lap_time, sector1_time, sector2_time, sector3_time, lap_valid, sector1_valid, sector2_valid, sector3_valid from telemetry.session_lap_data \nwhere cast($session_id as VARCHAR) = session_id\nand cast($driver_ID as varchar) = user_id\norder by lap_num",
                           "sql": {
                             "columns": [
                               {
@@ -1704,10 +1704,10 @@
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
                         "datasource": {
-                          "name": "bfqxwocqg2ewwd"
+                          "name": "ffr53wnc5ks1sf"
                         },
                         "spec": {
-                          "dataset": "postgres",
+                          "dataset": "formulatel",
                           "editorMode": "code",
                           "format": "table",
                           "rawQuery": true,
@@ -2038,14 +2038,14 @@
               "group": "grafana-postgresql-datasource",
               "version": "v0",
               "spec": {
-                "dataset": "postgres",
+                "dataset": "formulatel",
                 "editorMode": "builder",
                 "format": "table",
                 "meta": {
                   "valueField": "session_id"
                 },
-                "query": "SELECT session_id FROM vehicle_data LIMIT 50 ",
-                "rawSql": "SELECT session_id FROM vehicle_data GROUP BY session_id LIMIT 50 ",
+                "query": "SELECT session_id FROM telemetry.vehicle_data LIMIT 50 ",
+                "rawSql": "SELECT session_id FROM telemetry.vehicle_data GROUP BY session_id LIMIT 50 ",
                 "refId": "SQLVariableQueryEditor-VariableQuery",
                 "sql": {
                   "columns": [
@@ -2076,7 +2076,7 @@
             "regex": "",
             "regexApplyTo": "value",
             "sort": "disabled",
-            "definition": "SELECT session_id FROM vehicle_data LIMIT 50 ",
+            "definition": "SELECT session_id FROM telemetry.vehicle_data LIMIT 50 ",
             "options": [],
             "multi": false,
             "includeAll": false,
@@ -2101,12 +2101,12 @@
               "group": "grafana-postgresql-datasource",
               "version": "v0",
               "spec": {
-                "dataset": "postgres",
+                "dataset": "formulatel",
                 "editorMode": "code",
                 "format": "table",
                 "meta": {},
-                "query": "SELECT user_id FROM vehicle_data LIMIT 50 ",
-                "rawSql": "SELECT user_id FROM vehicle_data LIMIT 50 ",
+                "query": "SELECT user_id FROM telemetry.vehicle_data LIMIT 50 ",
+                "rawSql": "SELECT user_id FROM telemetry.vehicle_data LIMIT 50 ",
                 "refId": "SQLVariableQueryEditor-VariableQuery",
                 "sql": {
                   "columns": [
@@ -2134,7 +2134,7 @@
             "regex": "",
             "regexApplyTo": "value",
             "sort": "disabled",
-            "definition": "SELECT user_id FROM vehicle_data LIMIT 50 ",
+            "definition": "SELECT user_id FROM telemetry.vehicle_data LIMIT 50 ",
             "options": [],
             "multi": false,
             "includeAll": false,

--- a/kubernetes/config/dashboards/dashboard-static.json
+++ b/kubernetes/config/dashboards/dashboard-static.json
@@ -4,21 +4,10 @@
     "kind": "Dashboard",
     "metadata": {
       "name": "gx2vh4",
-      "namespace": "default",
-      "uid": "2f5db16b-c8f2-4536-ab49-4727823089aa",
-      "resourceVersion": "1781816129630997",
       "generation": 2,
-      "creationTimestamp": "2026-06-18T19:54:10Z",
-      "labels": {
-        "grafana.app/deprecatedInternalID": "545170023317504"
-      },
-      "annotations": {
-        "grafana.app/createdBy": "anonymous:0",
-        "grafana.app/folder": "",
-        "grafana.app/saved-from-ui": "Grafana v13.0.2 (3fcdbc5a)",
-        "grafana.app/updatedBy": "anonymous:0",
-        "grafana.app/updatedTimestamp": "2026-06-18T20:55:29Z"
-      }
+      "creationTimestamp": "2026-07-22T16:35:05Z",
+      "labels": {},
+      "annotations": {}
     },
     "spec": {
       "annotations": [
@@ -45,15 +34,12 @@
               "kind": "DataQuery",
               "group": "grafana-postgresql-datasource",
               "version": "v0",
-              "datasource": {
-                "name": "ffr53wnc5ks1sf"
-              },
               "spec": {
                 "dataset": "formulatel",
                 "editorMode": "code",
                 "format": "table",
                 "rawQuery": true,
-                "rawSql": "SELECT\n  distinct current_lap_time, max(time) as time,\n  'Lap ' || lap_num - 1 || ' (' || current_lap_time || 'ms)' AS text,\n  'lap-marker' AS tags\nFROM telemetry.live_lap_data\nWHERE $__timeFilter(time) AND current_lap_time > 0\ngroup by current_lap_time, lap_num\nORDER BY time ASC;",
+                "rawSql": "SELECT\n  distinct current_lap_time, max(time) as time,\n  'Lap ' || lap_num - 1 || ' (' || current_lap_time || 'ms)' AS text,\n  'lap-marker' AS tags\nFROM telemetry.live_lap_data\nWHERE $__timeFilter(time) AND current_lap_time > 0 AND '$session_id' = live_lap_data.session_id AND live_lap_data.user_id = '$driver_ID'\ngroup by current_lap_time, lap_num\nORDER BY time ASC;",
                 "refId": "Anno",
                 "sql": {
                   "columns": [
@@ -72,6 +58,10 @@
                   ],
                   "limit": 50
                 }
+              },
+              "labels": {
+                "grafana.app/export-label": "grafana-postgresql-datasource-1",
+                "grafana.app/export-datasource-name": "formulatel-postgresql"
               }
             },
             "enable": true,
@@ -116,32 +106,16 @@
                         "kind": "DataQuery",
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "ffr53wnc5ks1sf"
-                        },
                         "spec": {
-                          "dataset": "formulatel",
-                          "editorMode": "builder",
+                          "dataset": "postgres",
+                          "editorMode": "code",
                           "format": "time_series",
-                          "rawSql": "SELECT \"time\", speed FROM telemetry.vehicle_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
+                          "rawQuery": true,
+                          "rawSql": "SELECT time, speed FROM telemetry.vehicle_data WHERE $__timeFilter(time) AND session_id = '$session_id' ORDER BY time DESC",
                           "sql": {
                             "columns": [
                               {
-                                "parameters": [
-                                  {
-                                    "name": "\"time\"",
-                                    "type": "functionParameter"
-                                  }
-                                ],
-                                "type": "function"
-                              },
-                              {
-                                "parameters": [
-                                  {
-                                    "name": "speed",
-                                    "type": "functionParameter"
-                                  }
-                                ],
+                                "parameters": [],
                                 "type": "function"
                               }
                             ],
@@ -153,45 +127,16 @@
                                 "type": "groupBy"
                               }
                             ],
-                            "limit": 3000,
-                            "orderBy": {
-                              "property": {
-                                "name": "\"time\"",
-                                "type": "string"
-                              },
-                              "type": "property"
-                            },
-                            "orderByDirection": "DESC",
+                            "limit": 50,
                             "whereJsonTree": {
-                              "children1": [
-                                {
-                                  "id": "9b9889a9-cdef-4012-b456-719e4cf065d0",
-                                  "properties": {
-                                    "field": "session_id",
-                                    "fieldSrc": "field",
-                                    "operator": "equal",
-                                    "value": [
-                                      "$session_id"
-                                    ],
-                                    "valueError": [
-                                      null
-                                    ],
-                                    "valueSrc": [
-                                      "value"
-                                    ],
-                                    "valueType": [
-                                      "text"
-                                    ]
-                                  },
-                                  "type": "rule"
-                                }
-                              ],
-                              "id": "99a998b9-0123-4456-b89a-b19e4cd49e1f",
+                              "id": "89ab9a8a-0123-4456-b89a-b19f8a57ff33",
                               "type": "group"
-                            },
-                            "whereString": "session_id = '$session_id'"
-                          },
-                          "table": "vehicle_data"
+                            }
+                          }
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-postgresql-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-postgresql"
                         }
                       },
                       "refId": "A",
@@ -206,7 +151,7 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "timeseries",
-              "version": "13.0.2",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "annotations": {
@@ -216,6 +161,8 @@
                   "legend": {
                     "calcs": [],
                     "displayMode": "list",
+                    "enableFacetedFilter": false,
+                    "overflow": "ellipsis",
                     "placement": "bottom",
                     "showLegend": true
                   },
@@ -299,15 +246,12 @@
                         "kind": "DataQuery",
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "ffr53wnc5ks1sf"
-                        },
                         "spec": {
                           "dataset": "formulatel",
                           "editorMode": "code",
                           "format": "table",
                           "rawQuery": true,
-                          "rawSql": "SELECT abs(bl_slip_ratio) as \"back_left\", abs(br_slip_ratio) as \"back_right\", abs(fl_slip_ratio) as \"front_left\", abs(fr_slip_ratio) as \"front_right\" FROM extended_wheel_data where $__timeFilter(\"time\")",
+                          "rawSql": "SELECT abs(bl_slip_ratio) as \"back_left\", abs(br_slip_ratio) as \"back_right\", abs(fl_slip_ratio) as \"front_left\", abs(fr_slip_ratio) as \"front_right\" FROM telemetry.extended_wheel_data where $__timeFilter(time) ORDER BY time DESC",
                           "sql": {
                             "columns": [
                               {
@@ -325,6 +269,10 @@
                             ],
                             "limit": 50
                           }
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-postgresql-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-postgresql"
                         }
                       },
                       "refId": "A",
@@ -339,7 +287,7 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "stat",
-              "version": "13.0.2",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "colorMode": "value",
@@ -388,7 +336,8 @@
                     },
                     "color": {
                       "mode": "thresholds"
-                    }
+                    },
+                    "noValue": "0"
                   },
                   "overrides": []
                 }
@@ -414,32 +363,16 @@
                         "kind": "DataQuery",
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "ffr53wnc5ks1sf"
-                        },
                         "spec": {
-                          "dataset": "formulatel",
-                          "editorMode": "builder",
+                          "dataset": "postgres",
+                          "editorMode": "code",
                           "format": "time_series",
-                          "rawSql": "SELECT \"time\", rpm FROM telemetry.vehicle_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
+                          "rawQuery": true,
+                          "rawSql": "SELECT \"time\", rpm FROM telemetry.vehicle_data WHERE $__timeFilter(time) AND session_id = '$session_id' ORDER BY time",
                           "sql": {
                             "columns": [
                               {
-                                "parameters": [
-                                  {
-                                    "name": "\"time\"",
-                                    "type": "functionParameter"
-                                  }
-                                ],
-                                "type": "function"
-                              },
-                              {
-                                "parameters": [
-                                  {
-                                    "name": "rpm",
-                                    "type": "functionParameter"
-                                  }
-                                ],
+                                "parameters": [],
                                 "type": "function"
                               }
                             ],
@@ -451,45 +384,16 @@
                                 "type": "groupBy"
                               }
                             ],
-                            "limit": 3000,
-                            "orderBy": {
-                              "property": {
-                                "name": "\"time\"",
-                                "type": "string"
-                              },
-                              "type": "property"
-                            },
-                            "orderByDirection": "DESC",
+                            "limit": 50,
                             "whereJsonTree": {
-                              "children1": [
-                                {
-                                  "id": "89ba9bab-4567-489a-bcde-f19e4cf17037",
-                                  "properties": {
-                                    "field": "session_id",
-                                    "fieldSrc": "field",
-                                    "operator": "equal",
-                                    "value": [
-                                      "$session_id"
-                                    ],
-                                    "valueError": [
-                                      null
-                                    ],
-                                    "valueSrc": [
-                                      "value"
-                                    ],
-                                    "valueType": [
-                                      "text"
-                                    ]
-                                  },
-                                  "type": "rule"
-                                }
-                              ],
-                              "id": "99a998b9-0123-4456-b89a-b19e4cd49e1f",
+                              "id": "89ab9a8a-0123-4456-b89a-b19f8a57ff33",
                               "type": "group"
-                            },
-                            "whereString": "session_id = '$session_id'"
-                          },
-                          "table": "vehicle_data"
+                            }
+                          }
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-postgresql-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-postgresql"
                         }
                       },
                       "refId": "A",
@@ -504,7 +408,7 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "timeseries",
-              "version": "13.0.2",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "annotations": {
@@ -514,6 +418,8 @@
                   "legend": {
                     "calcs": [],
                     "displayMode": "list",
+                    "enableFacetedFilter": false,
+                    "overflow": "ellipsis",
                     "placement": "bottom",
                     "showLegend": true
                   },
@@ -601,50 +507,16 @@
                         "kind": "DataQuery",
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "ffr53wnc5ks1sf"
-                        },
                         "spec": {
-                          "dataset": "formulatel",
-                          "editorMode": "builder",
+                          "dataset": "postgres",
+                          "editorMode": "code",
                           "format": "time_series",
-                          "rawSql": "SELECT \"time\", gforce_lateral, gforce_longitudinal, gforce_vertical FROM telemetry.motion_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
+                          "rawQuery": true,
+                          "rawSql": "SELECT \"time\", gforce_lateral, gforce_longitudinal, gforce_vertical FROM telemetry.motion_data WHERE $__timeFilter(time) AND session_id = '$session_id' AND user_id = '$driver_ID' ORDER BY \"time\" DESC",
                           "sql": {
                             "columns": [
                               {
-                                "parameters": [
-                                  {
-                                    "name": "\"time\"",
-                                    "type": "functionParameter"
-                                  }
-                                ],
-                                "type": "function"
-                              },
-                              {
-                                "parameters": [
-                                  {
-                                    "name": "gforce_lateral",
-                                    "type": "functionParameter"
-                                  }
-                                ],
-                                "type": "function"
-                              },
-                              {
-                                "parameters": [
-                                  {
-                                    "name": "gforce_longitudinal",
-                                    "type": "functionParameter"
-                                  }
-                                ],
-                                "type": "function"
-                              },
-                              {
-                                "parameters": [
-                                  {
-                                    "name": "gforce_vertical",
-                                    "type": "functionParameter"
-                                  }
-                                ],
+                                "parameters": [],
                                 "type": "function"
                               }
                             ],
@@ -656,45 +528,16 @@
                                 "type": "groupBy"
                               }
                             ],
-                            "limit": 3000,
-                            "orderBy": {
-                              "property": {
-                                "name": "\"time\"",
-                                "type": "string"
-                              },
-                              "type": "property"
-                            },
-                            "orderByDirection": "DESC",
+                            "limit": 50,
                             "whereJsonTree": {
-                              "children1": [
-                                {
-                                  "id": "ba89898a-cdef-4012-b456-719e4cf38ec2",
-                                  "properties": {
-                                    "field": "session_id",
-                                    "fieldSrc": "field",
-                                    "operator": "equal",
-                                    "value": [
-                                      "$session_id"
-                                    ],
-                                    "valueError": [
-                                      null
-                                    ],
-                                    "valueSrc": [
-                                      "value"
-                                    ],
-                                    "valueType": [
-                                      "text"
-                                    ]
-                                  },
-                                  "type": "rule"
-                                }
-                              ],
-                              "id": "99a998b9-0123-4456-b89a-b19e4cd49e1f",
+                              "id": "89ab9a8a-0123-4456-b89a-b19f8a57ff33",
                               "type": "group"
-                            },
-                            "whereString": "session_id = '$session_id'"
-                          },
-                          "table": "motion_data"
+                            }
+                          }
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-postgresql-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-postgresql"
                         }
                       },
                       "refId": "A",
@@ -709,7 +552,7 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "timeseries",
-              "version": "13.0.2",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "annotations": {
@@ -719,6 +562,8 @@
                   "legend": {
                     "calcs": [],
                     "displayMode": "list",
+                    "enableFacetedFilter": false,
+                    "overflow": "ellipsis",
                     "placement": "bottom",
                     "showLegend": true
                   },
@@ -806,50 +651,16 @@
                         "kind": "DataQuery",
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "ffr53wnc5ks1sf"
-                        },
                         "spec": {
-                          "dataset": "formulatel",
-                          "editorMode": "builder",
+                          "dataset": "postgres",
+                          "editorMode": "code",
                           "format": "time_series",
-                          "rawSql": "SELECT \"time\", velocity_x, velocity_y, velocity_z FROM telemetry.motion_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
+                          "rawQuery": true,
+                          "rawSql": "SELECT \"time\", velocity_x, velocity_y, velocity_z FROM telemetry.motion_data WHERE $__timeFilter(time) AND session_id = '$session_id' AND user_id = '$driver_ID' ORDER BY \"time\"",
                           "sql": {
                             "columns": [
                               {
-                                "parameters": [
-                                  {
-                                    "name": "\"time\"",
-                                    "type": "functionParameter"
-                                  }
-                                ],
-                                "type": "function"
-                              },
-                              {
-                                "parameters": [
-                                  {
-                                    "name": "velocity_x",
-                                    "type": "functionParameter"
-                                  }
-                                ],
-                                "type": "function"
-                              },
-                              {
-                                "parameters": [
-                                  {
-                                    "name": "velocity_y",
-                                    "type": "functionParameter"
-                                  }
-                                ],
-                                "type": "function"
-                              },
-                              {
-                                "parameters": [
-                                  {
-                                    "name": "velocity_z",
-                                    "type": "functionParameter"
-                                  }
-                                ],
+                                "parameters": [],
                                 "type": "function"
                               }
                             ],
@@ -861,45 +672,16 @@
                                 "type": "groupBy"
                               }
                             ],
-                            "limit": 3000,
-                            "orderBy": {
-                              "property": {
-                                "name": "\"time\"",
-                                "type": "string"
-                              },
-                              "type": "property"
-                            },
-                            "orderByDirection": "DESC",
+                            "limit": 50,
                             "whereJsonTree": {
-                              "children1": [
-                                {
-                                  "id": "ba89898a-cdef-4012-b456-719e4cf38ec2",
-                                  "properties": {
-                                    "field": "session_id",
-                                    "fieldSrc": "field",
-                                    "operator": "equal",
-                                    "value": [
-                                      "$session_id"
-                                    ],
-                                    "valueError": [
-                                      null
-                                    ],
-                                    "valueSrc": [
-                                      "value"
-                                    ],
-                                    "valueType": [
-                                      "text"
-                                    ]
-                                  },
-                                  "type": "rule"
-                                }
-                              ],
-                              "id": "99a998b9-0123-4456-b89a-b19e4cd49e1f",
+                              "id": "89ab9a8a-0123-4456-b89a-b19f8a57ff33",
                               "type": "group"
-                            },
-                            "whereString": "session_id = '$session_id'"
-                          },
-                          "table": "motion_data"
+                            }
+                          }
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-postgresql-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-postgresql"
                         }
                       },
                       "refId": "A",
@@ -914,7 +696,7 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "timeseries",
-              "version": "13.0.2",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "annotations": {
@@ -924,6 +706,8 @@
                   "legend": {
                     "calcs": [],
                     "displayMode": "list",
+                    "enableFacetedFilter": false,
+                    "overflow": "ellipsis",
                     "placement": "bottom",
                     "showLegend": true
                   },
@@ -1007,15 +791,12 @@
                         "kind": "DataQuery",
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "ffr53wnc5ks1sf"
-                        },
                         "spec": {
                           "dataset": "formulatel",
                           "editorMode": "code",
                           "format": "time_series",
                           "rawQuery": true,
-                          "rawSql": "SELECT \"time\", throttle, -brake as brake FROM telemetry.vehicle_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
+                          "rawSql": "SELECT \"time\", throttle, -brake as brake FROM telemetry.vehicle_data WHERE $__timeFilter(time) AND session_id = '$session_id' AND user_id = '$driver_ID' ORDER BY \"time\" DESC",
                           "sql": {
                             "columns": [
                               {
@@ -1093,6 +874,10 @@
                             "whereString": "session_id = '$session_id'"
                           },
                           "table": "vehicle_data"
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-postgresql-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-postgresql"
                         }
                       },
                       "refId": "A",
@@ -1107,7 +892,7 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "timeseries",
-              "version": "13.0.2",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "annotations": {
@@ -1117,6 +902,8 @@
                   "legend": {
                     "calcs": [],
                     "displayMode": "list",
+                    "enableFacetedFilter": false,
+                    "overflow": "ellipsis",
                     "placement": "bottom",
                     "showLegend": true
                   },
@@ -1191,7 +978,7 @@
           "spec": {
             "id": 6,
             "title": "brake temps",
-            "description": "vehicle RPM over time",
+            "description": "brake temperatures",
             "links": [],
             "data": {
               "kind": "QueryGroup",
@@ -1204,63 +991,16 @@
                         "kind": "DataQuery",
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "ffr53wnc5ks1sf"
-                        },
                         "spec": {
-                          "dataset": "formulatel",
-                          "editorMode": "builder",
+                          "dataset": "postgres",
+                          "editorMode": "code",
                           "format": "time_series",
-                          "rawSql": "SELECT \"time\", fl_brake_temp AS \"front left\", fr_brake_temp AS \"front right\", bl_brake_temp AS \"back left\", br_brake_temp AS \"back right\" FROM telemetry.vehicle_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
+                          "rawQuery": true,
+                          "rawSql": "SELECT \"time\", fl_brake_temp AS \"front left\", fr_brake_temp AS \"front right\", bl_brake_temp AS \"back left\", br_brake_temp AS \"back right\" FROM telemetry.vehicle_data WHERE $__timeFilter(time) AND session_id = '$session_id' ORDER BY \"time\" DESC ",
                           "sql": {
                             "columns": [
                               {
-                                "parameters": [
-                                  {
-                                    "name": "\"time\"",
-                                    "type": "functionParameter"
-                                  }
-                                ],
-                                "type": "function"
-                              },
-                              {
-                                "alias": "\"front left\"",
-                                "parameters": [
-                                  {
-                                    "name": "fl_brake_temp",
-                                    "type": "functionParameter"
-                                  }
-                                ],
-                                "type": "function"
-                              },
-                              {
-                                "alias": "\"front right\"",
-                                "parameters": [
-                                  {
-                                    "name": "fr_brake_temp",
-                                    "type": "functionParameter"
-                                  }
-                                ],
-                                "type": "function"
-                              },
-                              {
-                                "alias": "\"back left\"",
-                                "parameters": [
-                                  {
-                                    "name": "bl_brake_temp",
-                                    "type": "functionParameter"
-                                  }
-                                ],
-                                "type": "function"
-                              },
-                              {
-                                "alias": "\"back right\"",
-                                "parameters": [
-                                  {
-                                    "name": "br_brake_temp",
-                                    "type": "functionParameter"
-                                  }
-                                ],
+                                "parameters": [],
                                 "type": "function"
                               }
                             ],
@@ -1272,45 +1012,16 @@
                                 "type": "groupBy"
                               }
                             ],
-                            "limit": 3000,
-                            "orderBy": {
-                              "property": {
-                                "name": "\"time\"",
-                                "type": "string"
-                              },
-                              "type": "property"
-                            },
-                            "orderByDirection": "DESC",
+                            "limit": 50,
                             "whereJsonTree": {
-                              "children1": [
-                                {
-                                  "id": "89ba9bab-4567-489a-bcde-f19e4cf17037",
-                                  "properties": {
-                                    "field": "session_id",
-                                    "fieldSrc": "field",
-                                    "operator": "equal",
-                                    "value": [
-                                      "$session_id"
-                                    ],
-                                    "valueError": [
-                                      null
-                                    ],
-                                    "valueSrc": [
-                                      "value"
-                                    ],
-                                    "valueType": [
-                                      "text"
-                                    ]
-                                  },
-                                  "type": "rule"
-                                }
-                              ],
-                              "id": "99a998b9-0123-4456-b89a-b19e4cd49e1f",
+                              "id": "89ab9a8a-0123-4456-b89a-b19f8a57ff33",
                               "type": "group"
-                            },
-                            "whereString": "session_id = '$session_id'"
-                          },
-                          "table": "vehicle_data"
+                            }
+                          }
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-postgresql-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-postgresql"
                         }
                       },
                       "refId": "A",
@@ -1325,7 +1036,7 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "timeseries",
-              "version": "13.0.2",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "annotations": {
@@ -1335,6 +1046,8 @@
                   "legend": {
                     "calcs": [],
                     "displayMode": "list",
+                    "enableFacetedFilter": false,
+                    "overflow": "ellipsis",
                     "placement": "bottom",
                     "showLegend": true
                   },
@@ -1419,32 +1132,16 @@
                         "kind": "DataQuery",
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "ffr53wnc5ks1sf"
-                        },
                         "spec": {
-                          "dataset": "formulatel",
-                          "editorMode": "builder",
+                          "dataset": "postgres",
+                          "editorMode": "code",
                           "format": "table",
-                          "rawSql": "SELECT \"time\", yaw FROM telemetry.motion_data WHERE session_id = '$session_id' ORDER BY \"time\" DESC LIMIT 3000 ",
+                          "rawQuery": true,
+                          "rawSql": "SELECT \"time\", yaw FROM telemetry.motion_data WHERE $__timeFilter(time) AND session_id = '$session_id' AND user_id = '$driver_ID' ORDER BY \"time\" DESC",
                           "sql": {
                             "columns": [
                               {
-                                "parameters": [
-                                  {
-                                    "name": "\"time\"",
-                                    "type": "functionParameter"
-                                  }
-                                ],
-                                "type": "function"
-                              },
-                              {
-                                "parameters": [
-                                  {
-                                    "name": "yaw",
-                                    "type": "functionParameter"
-                                  }
-                                ],
+                                "parameters": [],
                                 "type": "function"
                               }
                             ],
@@ -1456,45 +1153,16 @@
                                 "type": "groupBy"
                               }
                             ],
-                            "limit": 3000,
-                            "orderBy": {
-                              "property": {
-                                "name": "\"time\"",
-                                "type": "string"
-                              },
-                              "type": "property"
-                            },
-                            "orderByDirection": "DESC",
+                            "limit": 50,
                             "whereJsonTree": {
-                              "children1": [
-                                {
-                                  "id": "aaabab89-4567-489a-bcde-f19e4d130a4c",
-                                  "properties": {
-                                    "field": "session_id",
-                                    "fieldSrc": "field",
-                                    "operator": "equal",
-                                    "value": [
-                                      "$session_id"
-                                    ],
-                                    "valueError": [
-                                      null
-                                    ],
-                                    "valueSrc": [
-                                      "value"
-                                    ],
-                                    "valueType": [
-                                      "text"
-                                    ]
-                                  },
-                                  "type": "rule"
-                                }
-                              ],
-                              "id": "99a998b9-0123-4456-b89a-b19e4cd49e1f",
+                              "id": "89ab9a8a-0123-4456-b89a-b19f8a57ff33",
                               "type": "group"
-                            },
-                            "whereString": "session_id = '$session_id'"
-                          },
-                          "table": "motion_data"
+                            }
+                          }
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-postgresql-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-postgresql"
                         }
                       },
                       "refId": "A",
@@ -1509,7 +1177,7 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "timeseries",
-              "version": "13.0.2",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "annotations": {
@@ -1519,6 +1187,8 @@
                   "legend": {
                     "calcs": [],
                     "displayMode": "list",
+                    "enableFacetedFilter": false,
+                    "overflow": "ellipsis",
                     "placement": "bottom",
                     "showLegend": true
                   },
@@ -1606,15 +1276,12 @@
                         "kind": "DataQuery",
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "ffr53wnc5ks1sf"
-                        },
                         "spec": {
                           "dataset": "formulatel",
                           "editorMode": "code",
                           "format": "table",
                           "rawQuery": true,
-                          "rawSql": "select lap_num, lap_time, sector1_time, sector2_time, sector3_time, lap_valid, sector1_valid, sector2_valid, sector3_valid from telemetry.session_lap_data \nwhere cast($session_id as VARCHAR) = session_id\nand cast($driver_ID as varchar) = user_id\norder by lap_num",
+                          "rawSql": "select lap_num, lap_time, sector1_time, sector2_time, sector3_time, lap_valid, sector1_valid, sector2_valid, sector3_valid \nfrom telemetry.session_lap_data\nwhere session_id = '$session_id' and user_id = '$driver_ID'\nORDER BY lap_num",
                           "sql": {
                             "columns": [
                               {
@@ -1633,6 +1300,10 @@
                             "limit": 50
                           },
                           "table": "session_lap_data"
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-postgresql-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-postgresql"
                         }
                       },
                       "refId": "A",
@@ -1647,7 +1318,7 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "table",
-              "version": "13.0.2",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "cellHeight": "sm",
@@ -1703,15 +1374,12 @@
                         "kind": "DataQuery",
                         "group": "grafana-postgresql-datasource",
                         "version": "v0",
-                        "datasource": {
-                          "name": "ffr53wnc5ks1sf"
-                        },
                         "spec": {
                           "dataset": "formulatel",
                           "editorMode": "code",
                           "format": "table",
                           "rawQuery": true,
-                          "rawSql": "SELECT bl_slip_angle as \"back_left\", br_slip_angle as \"back_right\", fl_slip_angle as \"front_left\", fr_slip_angle as \"front_right\" FROM extended_wheel_data where $__timeFilter(\"time\") ",
+                          "rawSql": "SELECT bl_slip_angle as \"back_left\", br_slip_angle as \"back_right\", fl_slip_angle as \"front_left\", fr_slip_angle as \"front_right\" FROM telemetry.extended_wheel_data where $__timeFilter(\"time\") AND session_id = '$session_id'  ORDER BY time DESC",
                           "sql": {
                             "columns": [
                               {
@@ -1735,6 +1403,10 @@
                             "limit": 50
                           },
                           "table": "extended_wheel_data"
+                        },
+                        "labels": {
+                          "grafana.app/export-label": "grafana-postgresql-datasource-1",
+                          "grafana.app/export-datasource-name": "formulatel-postgresql"
                         }
                       },
                       "refId": "A",
@@ -1749,7 +1421,7 @@
             "vizConfig": {
               "kind": "VizConfig",
               "group": "stat",
-              "version": "13.0.2",
+              "version": "13.1.0",
               "spec": {
                 "options": {
                   "colorMode": "value",
@@ -1786,7 +1458,8 @@
                     },
                     "color": {
                       "mode": "thresholds"
-                    }
+                    },
+                    "noValue": "0"
                   },
                   "overrides": []
                 }
@@ -2023,6 +1696,67 @@
         {
           "kind": "QueryVariable",
           "spec": {
+            "name": "Driver",
+            "current": {
+              "text": "",
+              "value": ""
+            },
+            "hide": "dontHide",
+            "refresh": "onDashboardLoad",
+            "skipUrlSync": false,
+            "query": {
+              "kind": "DataQuery",
+              "group": "grafana-postgresql-datasource",
+              "version": "v0",
+              "spec": {
+                "dataset": "postgres",
+                "editorMode": "builder",
+                "format": "table",
+                "query": "",
+                "rawSql": "SELECT username FROM telemetry.users LIMIT 50 ",
+                "refId": "SQLVariableQueryEditor-VariableQuery",
+                "sql": {
+                  "columns": [
+                    {
+                      "parameters": [
+                        {
+                          "name": "username",
+                          "type": "functionParameter"
+                        }
+                      ],
+                      "type": "function"
+                    }
+                  ],
+                  "groupBy": [
+                    {
+                      "property": {
+                        "type": "string"
+                      },
+                      "type": "groupBy"
+                    }
+                  ],
+                  "limit": 50
+                },
+                "table": "telemetry.users"
+              },
+              "labels": {
+                "grafana.app/export-label": "grafana-postgresql-datasource-1",
+                "grafana.app/export-datasource-name": "formulatel-postgresql"
+              }
+            },
+            "regex": "",
+            "regexApplyTo": "value",
+            "sort": "disabled",
+            "definition": "",
+            "options": [],
+            "multi": false,
+            "includeAll": false,
+            "allowCustomValue": true
+          }
+        },
+        {
+          "kind": "QueryVariable",
+          "spec": {
             "name": "session_id",
             "current": {
               "text": "",
@@ -2030,7 +1764,7 @@
             },
             "label": "Session ID",
             "hide": "dontHide",
-            "refresh": "onDashboardLoad",
+            "refresh": "onTimeRangeChanged",
             "skipUrlSync": false,
             "description": "ID of the session, e.g. free practise, race, time-trial",
             "query": {
@@ -2038,14 +1772,13 @@
               "group": "grafana-postgresql-datasource",
               "version": "v0",
               "spec": {
-                "dataset": "formulatel",
-                "editorMode": "builder",
+                "dataset": "postgres",
+                "editorMode": "code",
                 "format": "table",
-                "meta": {
-                  "valueField": "session_id"
-                },
-                "query": "SELECT session_id FROM telemetry.vehicle_data LIMIT 50 ",
-                "rawSql": "SELECT session_id FROM telemetry.vehicle_data GROUP BY session_id LIMIT 50 ",
+                "meta": {},
+                "query": "SELECT distinct session_id FROM telemetry.motion_data WHERE time >= current_timestamp - interval '7' day",
+                "rawQuery": true,
+                "rawSql": "SELECT distinct session_id FROM telemetry.motion_data WHERE time >= current_timestamp - interval '7' day",
                 "refId": "SQLVariableQueryEditor-VariableQuery",
                 "sql": {
                   "columns": [
@@ -2062,7 +1795,6 @@
                   "groupBy": [
                     {
                       "property": {
-                        "name": "session_id",
                         "type": "string"
                       },
                       "type": "groupBy"
@@ -2070,17 +1802,17 @@
                   ],
                   "limit": 50
                 },
-                "table": "vehicle_data"
+                "table": "telemetry.motion_data"
               }
             },
             "regex": "",
             "regexApplyTo": "value",
-            "sort": "disabled",
-            "definition": "SELECT session_id FROM telemetry.vehicle_data LIMIT 50 ",
+            "sort": "alphabeticalAsc",
+            "definition": "SELECT distinct session_id FROM telemetry.motion_data WHERE time >= current_timestamp - interval '7' day",
             "options": [],
             "multi": false,
             "includeAll": false,
-            "allowCustomValue": true
+            "allowCustomValue": false
           }
         },
         {
@@ -2104,9 +1836,12 @@
                 "dataset": "formulatel",
                 "editorMode": "code",
                 "format": "table",
-                "meta": {},
-                "query": "SELECT user_id FROM telemetry.vehicle_data LIMIT 50 ",
-                "rawSql": "SELECT user_id FROM telemetry.vehicle_data LIMIT 50 ",
+                "meta": {
+                  "textField": "user_id"
+                },
+                "query": "SELECT user_id FROM telemetry.motion_data WHERE $__timeFilter(time) ",
+                "rawQuery": true,
+                "rawSql": "SELECT user_id FROM telemetry.motion_data WHERE $__timeFilter(time) ",
                 "refId": "SQLVariableQueryEditor-VariableQuery",
                 "sql": {
                   "columns": [
@@ -2134,7 +1869,7 @@
             "regex": "",
             "regexApplyTo": "value",
             "sort": "disabled",
-            "definition": "SELECT user_id FROM telemetry.vehicle_data LIMIT 50 ",
+            "definition": "SELECT user_id FROM telemetry.motion_data WHERE $__timeFilter(time) ",
             "options": [],
             "multi": false,
             "includeAll": false,

--- a/kubernetes/config/local/formulatel-values.yaml
+++ b/kubernetes/config/local/formulatel-values.yaml
@@ -146,5 +146,5 @@ app-template:
           # Queries
           auth_opt_pg_userquery SELECT password_hash FROM auth.accounts WHERE username = $1 LIMIT 1
           auth_opt_pg_superquery SELECT COUNT(*) FROM auth.accounts WHERE username = $1 AND is_admin = true
-          auth_opt_pg_aclquery SELECT topic FROM auth.mqtt_acls JOIN auth.accounts ON mqtt_acls.account_id=accounts.id WHERE username = $1 AND (access_level >= $2)
+          auth_opt_pg_aclquery SELECT topic FROM auth.mqtt_acls JOIN auth.accounts ON mqtt_acls.account_id=accounts.id WHERE username = $1 AND (access_level = $2 OR access_level = 3 OR $2 = 4)
           auth_opt_hasher bcrypt

--- a/kubernetes/config/staging/formulatel-values.yaml
+++ b/kubernetes/config/staging/formulatel-values.yaml
@@ -136,5 +136,5 @@ app-template:
           # Queries
           auth_opt_pg_userquery SELECT password_hash FROM auth.accounts WHERE username = $1 LIMIT 1
           auth_opt_pg_superquery SELECT COUNT(*) FROM auth.accounts WHERE username = $1 AND is_admin = true
-          auth_opt_pg_aclquery SELECT topic FROM auth.mqtt_acls JOIN auth.accounts ON mqtt_acls.account_id=accounts.id WHERE username = $1 AND (access_level >= $2)
+          auth_opt_pg_aclquery SELECT topic FROM auth.mqtt_acls JOIN auth.accounts ON mqtt_acls.account_id=accounts.id WHERE username = $1 AND (access_level = $2 OR access_level = 3 OR $2 = 4)
           auth_opt_hasher bcrypt

--- a/migrations/20260514001600_create_tenant_role_group.up.sql
+++ b/migrations/20260514001600_create_tenant_role_group.up.sql
@@ -8,3 +8,5 @@ BEGIN
 END
 $$;
 GRANT USAGE ON SCHEMA telemetry TO telemetry_readers;
+GRANT SELECT ON ALL TABLES IN SCHEMA telemetry TO telemetry_readers;
+ALTER DEFAULT PRIVILEGES IN SCHEMA telemetry GRANT SELECT ON TABLES TO telemetry_readers;

--- a/migrations/20260514001600_create_tenant_role_group.up.sql
+++ b/migrations/20260514001600_create_tenant_role_group.up.sql
@@ -8,5 +8,3 @@ BEGIN
 END
 $$;
 GRANT USAGE ON SCHEMA telemetry TO telemetry_readers;
-GRANT SELECT ON ALL TABLES IN SCHEMA telemetry TO telemetry_readers;
-ALTER DEFAULT PRIVILEGES IN SCHEMA telemetry GRANT SELECT ON TABLES TO telemetry_readers;

--- a/migrations/20260719211302_create_telemetry_users.down.sql
+++ b/migrations/20260719211302_create_telemetry_users.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS telemetry.users;

--- a/migrations/20260719211302_create_telemetry_users.up.sql
+++ b/migrations/20260719211302_create_telemetry_users.up.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS telemetry.users (
+  id UUID NOT NULL PRIMARY KEY,
+  tenant_id INT,
+  username VARCHAR(100) NOT NULL
+);
+
+ALTER TABLE telemetry.users ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_telemetry_readers ON telemetry.users USING (tenant_id = substring(CURRENT_USER from 'tenant_([0-9]+)')::int);
+
+GRANT SELECT ON telemetry.users TO telemetry_readers;
+
+COMMIT;

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,12 @@ The `formulatel` dashboards can be imported into a locally running Grafana using
 
 This requires `curl`.
 
+Alternatively, use the admin CLI to provision dashboards per-tenant:
+
+```bash
+./out/admin --grafana-admin-user=admin --grafana-admin-password=`kubectl get secret --namespace=formulatel formulatel-grafana -o yaml | yq -r '.data["admin-password"]' | base64 -d` --connstring='postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable' dashboard create --dashboard-file ./kubernetes/config/dashboards/dashboard-live.json --tenant 0
+```
+
 ### Formulatel tenants
 
 If you are running the `formulatel` chart with MQTT auth, you will need to create a username and password for ingest to authenticate with the broker. To do this, you can use the `formulatel admin` tool to create a tenant and a user for that tenant:
@@ -104,9 +110,12 @@ Then you can use the output role and token to authenticate with ingest and send 
 - [x] chart telemetry data
 - [x] build a dashboard for interesting telemetry data
 - [x] realtime charting with something like Grafana Live
+- [x] deploy as a public cloud service
+- [~] multi-tenancy in the cloud
 - [ ] insights? A lofty goal to be certain, but it'd be cool to alert on realtime data (ideal braking point? racing line? I don't know) or maybe predict when the tires will die or something.
 - [ ] eBPF packet inspection and routing - it'd be neat to route packets directly from the syscall using eBPF.
 - [ ] wouldn't it be neat to train a model, maybe even a live assistant (race engineer)? "try braking 50m earlier"; "you're turning in too early"; etc.
+- [ ] create a visibility dashboard to view the live health of the MQTT topics and `persist` service
 
 
 ## Architecture


### PR DESCRIPTION
- feat: Updated the hierarchy / structure of topics to make topic filters more straightforward
- feat: Added a new `telemetry.users` table that allows the tenant roles to list users of their tenancy. It is somewhat flakey, as the row security policy looks at the name of the user querying and checks it against the Grafana org ID that is requesting it.
  - fix: Updated `tenant create` to name the tenant role `tenant_<grafana_org_id>`
  - fix: Updated `user create` to insert a row to the new `telemetry.users` table. 
- feat: Updated live and static dashboards to use a `driver` variable that comes from the new `telemetry.users` table
- feat: added $__org and $driver to all topic filters.
- feat: added new `dashboard create` command to admin CLI to provision the live and static dashboards for a given tenant. This will only live as long as it takes me to rewrite the dashboards with the observability-as-code SDK; see https://github.com/grafana/grafana-foundation-sdk/tree/main/go
- feat: update `aclquery` in mosquitto.conf